### PR TITLE
Simplify GitHub Pages site layout and branding

### DIFF
--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -2,23 +2,11 @@ baseURL = 'https://britt.github.io/claude-code-skills/'
 languageCode = 'en-us'
 title = 'Claude Skills'
 theme = 'paper'
+copyright = '© 2026 Snugglebear Team Company'
 
 [params]
   color = 'linen'
-  twitter = ''
   github = 'britt/claude-code-skills'
   avatar = ''
   name = 'Claude Skills'
   bio = 'A collection of skills for Claude to enhance AI-assisted development workflows'
-
-[menu]
-  [[menu.main]]
-    identifier = "skills"
-    name = "Skills"
-    url = "/skills/"
-    weight = 1
-  [[menu.main]]
-    identifier = "docs"
-    name = "Docs"
-    url = "/docs/"
-    weight = 2

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -1,0 +1,44 @@
+{{- define "main" -}}
+
+<!-- avatar -->
+{{- $avatar_url := $.Scratch.Get "avatar_url" -}}
+{{- if or $avatar_url site.Params.name -}}
+<div class="-mt-2 mb-12 flex items-center">
+  {{- if $avatar_url -}}
+  <div
+    class="h-24 w-24 shrink-0 rounded-full border-[0.5px] border-black/10 bg-white/50 p-3 ltr:mr-5 ltr:-ml-1 rtl:-mr-1 rtl:ml-5 dark:bg-white/90!"
+  >
+    <img
+      class="not-prose my-0 h-full w-full rounded-full bg-black/5! hover:animate-spin dark:bg-black/80!"
+      src="{{- $avatar_url -}}"
+      alt="{{- site.Params.name | default site.Title -}}"
+    />
+  </div>
+  {{- end -}}
+  {{- if site.Params.name -}}
+  <div>
+    <div class="mt-3 mb-1 text-2xl font-medium text-black dark:text-white">
+      {{- site.Params.name -}}
+    </div>
+    <div class="break-words">
+      {{- site.Params.bio | default (print `A personal blog by `
+      site.Params.name) -}}
+    </div>
+  </div>
+  {{- end -}}
+</div>
+{{- end -}}
+
+<!-- Skills List -->
+{{- $skills := where site.RegularPages "Section" "skills" -}}
+{{- range $skills -}}
+<section class="relative my-10 first-of-type:mt-0 last-of-type:mb-0">
+  <h2 class="my-0!">{{- .Title -}}</h2>
+  <p class="mt-2 text-sm opacity-80">{{- .Params.description -}}</p>
+  <a class="absolute inset-0 text-[0px]" href="{{- .Permalink -}}"
+    >{{- .Title -}}</a
+  >
+</section>
+{{- end -}}
+
+{{- end -}}


### PR DESCRIPTION
## Summary
- Remove X/Twitter, Docs, and Skills links from the top navigation
- Add custom home page layout listing skills with titles and descriptions (no dates)
- Update copyright to "Snugglebear Team Company"

## Test plan
- [ ] Verify Hugo site builds successfully
- [ ] Check home page displays all skills with titles and descriptions
- [ ] Confirm navigation shows only site title and dark mode toggle
- [ ] Verify footer shows updated copyright

🤖 Generated with [Claude Code](https://claude.com/claude-code)