### PR TITLE
fix: render _index.md content on homepage

### DIFF
--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -29,16 +29,12 @@
 </div>
 {{- end -}}
 
-<!-- Skills List -->
-{{- $skills := where site.RegularPages "Section" "skills" -}}
-{{- range $skills -}}
-<section class="relative my-10 first-of-type:mt-0 last-of-type:mb-0">
-  <h2 class="my-0!">{{- .Title -}}</h2>
-  <p class="mt-2 text-sm opacity-80">{{- .Params.description -}}</p>
-  <a class="absolute inset-0 text-[0px]" href="{{- .Permalink -}}"
-    >{{- .Title -}}</a
-  >
-</section>
+<!-- Page content from _index.md -->
+{{- if .Content -}}
+<div class="prose dark:prose-invert max-w-none mb-12">
+  {{- .Content -}}
+</div>
 {{- end -}}
+
 
 {{- end -}}


### PR DESCRIPTION
## Summary
- Fixed homepage template to render `_index.md` markdown content
- Removed auto-generated skill cards (replaced by the markdown table in `_index.md`)

The homepage was ignoring `_index.md` content entirely because the `index.html` template never called `{{ .Content }}`. This caused the "What Are Claude Skills?" section, skills table, and Quick Start instructions to never appear.

## Test plan
- [ ] Verify homepage shows the full content from `_index.md`
- [ ] Confirm skills table with checkmarks renders correctly
- [ ] Confirm Quick Start installation instructions appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)