### PR TITLE
Hide page title on home page

### DIFF
--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -1,10 +1,9 @@
 {{- define "main" -}}
 
-<!-- avatar -->
+<!-- avatar (without name, since it duplicates site title in header) -->
 {{- $avatar_url := $.Scratch.Get "avatar_url" -}}
-{{- if or $avatar_url site.Params.name -}}
+{{- if $avatar_url -}}
 <div class="-mt-2 mb-12 flex items-center">
-  {{- if $avatar_url -}}
   <div
     class="h-24 w-24 shrink-0 rounded-full border-[0.5px] border-black/10 bg-white/50 p-3 ltr:mr-5 ltr:-ml-1 rtl:-mr-1 rtl:ml-5 dark:bg-white/90!"
   >
@@ -14,16 +13,9 @@
       alt="{{- site.Params.name | default site.Title -}}"
     />
   </div>
-  {{- end -}}
-  {{- if site.Params.name -}}
-  <div>
-    <div class="mt-3 mb-1 text-2xl font-medium text-black dark:text-white">
-      {{- site.Params.name -}}
-    </div>
-    <div class="break-words">
-      {{- site.Params.bio | default (print `A personal blog by `
-      site.Params.name) -}}
-    </div>
+  {{- if site.Params.bio -}}
+  <div class="break-words">
+    {{- site.Params.bio -}}
   </div>
   {{- end -}}
 </div>


### PR DESCRIPTION
## Summary
Remove the duplicate "Claude Skills" title from the home page that was appearing in both the header and the avatar section.

## Test plan
- [ ] View home page and verify "Claude Skills" appears only once in the header, not in the avatar section
- [ ] Verify avatar image still displays if configured
- [ ] Verify bio text still displays next to avatar if configured
- [ ] Check that non-home pages still display their page titles normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)