### PR TITLE
feat(docs): add semantic release commit examples

### DIFF
--- a/docs/examples/breaking-change-example.md
+++ b/docs/examples/breaking-change-example.md
@@ -1,0 +1,20 @@
+# Breaking Change Commit Example
+
+Demonstrates a `BREAKING CHANGE` commit — triggers a **major** version bump.
+
+## Commit format
+
+```
+perf(pencil): remove graphiteWidth option
+
+BREAKING CHANGE: The graphiteWidth option has been removed.
+The default graphite width of 10mm is always used for performance reasons.
+```
+
+## Version impact
+
+`1.0.0` → `2.0.0`
+
+## Note
+
+The `BREAKING CHANGE:` token must appear in the commit footer, not the subject line.

--- a/docs/examples/feat-example.md
+++ b/docs/examples/feat-example.md
@@ -1,0 +1,13 @@
+# Feature Commit Example
+
+Demonstrates a `feat()` commit — triggers a **minor** version bump.
+
+## Commit format
+
+```
+feat(pencil): add 'graphiteWidth' option
+```
+
+## Version impact
+
+`1.0.0` → `1.1.0`

--- a/docs/examples/fix-example.md
+++ b/docs/examples/fix-example.md
@@ -1,0 +1,13 @@
+# Fix Commit Example
+
+Demonstrates a `fix()` commit — triggers a **patch** version bump.
+
+## Commit format
+
+```
+fix(pencil): stop graphite breaking when too much pressure applied
+```
+
+## Version impact
+
+`1.0.0` → `1.0.1`

--- a/docs/examples/perf-example.md
+++ b/docs/examples/perf-example.md
@@ -1,0 +1,13 @@
+# Performance Commit Example
+
+Demonstrates a `perf()` commit — triggers a **patch** version bump.
+
+## Commit format
+
+```
+perf(pencil): optimize graphite rendering pipeline
+```
+
+## Version impact
+
+`1.0.0` → `1.0.1`


### PR DESCRIPTION
## Summary

Adds example documentation files demonstrating each semantic release commit type: fix (patch bump), feat (minor bump), perf (patch bump), and breaking change (major bump). Each file explains the commit format and its version impact, serving as a quick reference for contributors.

## Test plan

- [ ] Verify each example file renders correctly on GitHub
- [ ] Confirm the breaking change commit includes `BREAKING CHANGE:` in the footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)