### PR TITLE
fix(plugin): correct marketplace version pin and install command syntax

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code-skills",
   "description": "Skills for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "Britt Crawford",
     "email": "britt@brittcrawford.com"

--- a/README.md
+++ b/README.md
@@ -71,41 +71,41 @@ Add this repository as a plugin marketplace:
 **Install all skills:**
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 **Install individual skills:**
 
 ```bash
-/plugin install britt/architecture-diagramming
-/plugin install britt/at-risk-detection
-/plugin install britt/build-faq-from-issues
-/plugin install britt/consolidate-notes-summary
-/plugin install britt/context-aware-questions
-/plugin install britt/daily-planning-ritual
-/plugin install britt/dependency-mapping
-/plugin install britt/idea-to-design
-/plugin install britt/issue-decomposition
-/plugin install britt/markdown-formatting
-/plugin install britt/mermaid-diagrams
-/plugin install britt/prepare-meeting-agenda
-/plugin install britt/project-analysis
-/plugin install britt/project-planning
-/plugin install britt/requirement-elicitation
-/plugin install britt/research-topic-summarize
-/plugin install britt/sgai-goal
-/plugin install britt/setting-up-a-project
-/plugin install britt/stakeholder-tracking
-/plugin install britt/stakeholder-updates
-/plugin install britt/summarize-conversation-thread
-/plugin install britt/summoning-the-user
-/plugin install britt/timeline-planning
-/plugin install britt/triage-new-issues
-/plugin install britt/user-story-template
-/plugin install britt/working-on-an-issue
-/plugin install britt/writing-product-specs
-/plugin install britt/writing-user-stories
-/plugin install britt/writing-verification-plans
+/plugin install architecture-diagramming@britt
+/plugin install at-risk-detection@britt
+/plugin install build-faq-from-issues@britt
+/plugin install consolidate-notes-summary@britt
+/plugin install context-aware-questions@britt
+/plugin install daily-planning-ritual@britt
+/plugin install dependency-mapping@britt
+/plugin install idea-to-design@britt
+/plugin install issue-decomposition@britt
+/plugin install markdown-formatting@britt
+/plugin install mermaid-diagrams@britt
+/plugin install prepare-meeting-agenda@britt
+/plugin install project-analysis@britt
+/plugin install project-planning@britt
+/plugin install requirement-elicitation@britt
+/plugin install research-topic-summarize@britt
+/plugin install sgai-goal@britt
+/plugin install setting-up-a-project@britt
+/plugin install stakeholder-tracking@britt
+/plugin install stakeholder-updates@britt
+/plugin install summarize-conversation-thread@britt
+/plugin install summoning-the-user@britt
+/plugin install timeline-planning@britt
+/plugin install triage-new-issues@britt
+/plugin install user-story-template@britt
+/plugin install working-on-an-issue@britt
+/plugin install writing-product-specs@britt
+/plugin install writing-user-stories@britt
+/plugin install writing-verification-plans@britt
 ```
 
 ### Claude Code: Manual Installation

--- a/site/content/skills/architecture-diagramming.md
+++ b/site/content/skills/architecture-diagramming.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/architecture-diagramming
+/plugin install architecture-diagramming@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/at-risk-detection.md
+++ b/site/content/skills/at-risk-detection.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/at-risk-detection
+/plugin install at-risk-detection@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/build-faq-from-issues.md
+++ b/site/content/skills/build-faq-from-issues.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/build-faq-from-issues
+/plugin install build-faq-from-issues@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/consolidate-notes-summary.md
+++ b/site/content/skills/consolidate-notes-summary.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/consolidate-notes-summary
+/plugin install consolidate-notes-summary@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/context-aware-questions.md
+++ b/site/content/skills/context-aware-questions.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/context-aware-questions
+/plugin install context-aware-questions@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/daily-planning-ritual.md
+++ b/site/content/skills/daily-planning-ritual.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/daily-planning-ritual
+/plugin install daily-planning-ritual@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/dependency-mapping.md
+++ b/site/content/skills/dependency-mapping.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/dependency-mapping
+/plugin install dependency-mapping@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/idea-to-design.md
+++ b/site/content/skills/idea-to-design.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/idea-to-design
+/plugin install idea-to-design@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/issue-decomposition.md
+++ b/site/content/skills/issue-decomposition.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/issue-decomposition
+/plugin install issue-decomposition@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/markdown-formatting.md
+++ b/site/content/skills/markdown-formatting.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/markdown-formatting
+/plugin install markdown-formatting@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/mermaid-diagrams.md
+++ b/site/content/skills/mermaid-diagrams.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/mermaid-diagrams
+/plugin install mermaid-diagrams@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/prepare-meeting-agenda.md
+++ b/site/content/skills/prepare-meeting-agenda.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/prepare-meeting-agenda
+/plugin install prepare-meeting-agenda@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/project-analysis.md
+++ b/site/content/skills/project-analysis.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/project-analysis
+/plugin install project-analysis@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/project-planning.md
+++ b/site/content/skills/project-planning.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/project-planning
+/plugin install project-planning@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/requirement-elicitation.md
+++ b/site/content/skills/requirement-elicitation.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/requirement-elicitation
+/plugin install requirement-elicitation@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/research-topic-summarize.md
+++ b/site/content/skills/research-topic-summarize.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/research-topic-summarize
+/plugin install research-topic-summarize@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/setting-up-a-project.md
+++ b/site/content/skills/setting-up-a-project.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/setting-up-a-project
+/plugin install setting-up-a-project@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/stakeholder-tracking.md
+++ b/site/content/skills/stakeholder-tracking.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/stakeholder-tracking
+/plugin install stakeholder-tracking@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/stakeholder-updates.md
+++ b/site/content/skills/stakeholder-updates.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/stakeholder-updates
+/plugin install stakeholder-updates@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/summarize-conversation-thread.md
+++ b/site/content/skills/summarize-conversation-thread.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/summarize-conversation-thread
+/plugin install summarize-conversation-thread@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/summoning-the-user.md
+++ b/site/content/skills/summoning-the-user.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/summoning-the-user
+/plugin install summoning-the-user@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/timeline-planning.md
+++ b/site/content/skills/timeline-planning.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/timeline-planning
+/plugin install timeline-planning@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/triage-new-issues.md
+++ b/site/content/skills/triage-new-issues.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/triage-new-issues
+/plugin install triage-new-issues@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/user-story-template.md
+++ b/site/content/skills/user-story-template.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/user-story-template
+/plugin install user-story-template@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/working-on-an-issue.md
+++ b/site/content/skills/working-on-an-issue.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/working-on-an-issue
+/plugin install working-on-an-issue@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/writing-product-specs.md
+++ b/site/content/skills/writing-product-specs.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/writing-product-specs
+/plugin install writing-product-specs@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/writing-user-stories.md
+++ b/site/content/skills/writing-user-stories.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/writing-user-stories
+/plugin install writing-user-stories@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility

--- a/site/content/skills/writing-verification-plans.md
+++ b/site/content/skills/writing-verification-plans.md
@@ -11,13 +11,13 @@ Add the marketplace and install this skill:
 
 ```bash
 /plugin marketplace add britt/claude-code-skills
-/plugin install britt/writing-verification-plans
+/plugin install writing-verification-plans@britt
 ```
 
 Or install all skills at once:
 
 ```bash
-/plugin install britt/claude-code-skills
+/plugin install claude-code-skills@britt
 ```
 
 ## Compatibility


### PR DESCRIPTION
Verified the marketplace and plugin configuration against the official Claude Code docs and the bundled `claude plugin validate` tool, which surfaced two bugs. Bumped the root `plugin.json` to `1.3.0` so it matches the bundle's marketplace entry — they had drifted (`1.2.0` vs `1.3.0`), and since `plugin.json` wins at install time the entry was silently ignored, freezing existing users at `1.2.0`. Corrected the documented install command across the README and all 28 site skill pages from `/plugin install britt/<name>` to `/plugin install <name>@britt`, since the `owner/repo` form is only valid for `marketplace add` while install requires `<plugin-name>@<marketplace-name>`. The marketplace now passes `claude plugin validate . --strict` cleanly.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)