### PR TITLE
feat(marketplace): add project-foundations bundle plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "britt",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A collection of skills for Claude Code to enhance AI-assisted development workflows",
   "owner": {
     "name": "Britt Crawford",
@@ -19,6 +19,18 @@
       "source": "./",
       "category": "productivity",
       "tags": ["skills", "tdd", "planning", "specs", "development"]
+    },
+    {
+      "name": "project-foundations",
+      "description": "A curated bundle for taking a new project from concept to a diagrammed, story-driven plan: project setup, issue decomposition, user stories, verification plans, and architecture/dependency/Mermaid diagrams",
+      "version": "1.0.0",
+      "author": {
+        "name": "Britt Crawford",
+        "email": "britt@brittcrawford.com"
+      },
+      "source": "./bundles/project-foundations",
+      "category": "productivity",
+      "tags": ["bundle", "planning", "setup", "user-stories", "diagrams", "verification", "issues"]
     },
     {
       "name": "architecture-diagramming",

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ Add this repository as a plugin marketplace:
 /plugin install claude-code-skills@britt
 ```
 
+**Install a curated bundle:**
+
+```bash
+# project-foundations: setup, issue decomposition, user stories,
+# verification plans, and architecture/dependency/Mermaid diagrams
+/plugin install project-foundations@britt
+```
+
 **Install individual skills:**
 
 ```bash

--- a/bundles/project-foundations/.claude-plugin/plugin.json
+++ b/bundles/project-foundations/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "project-foundations",
+  "description": "A curated bundle for taking a new project from concept to a diagrammed, story-driven plan: project setup, issue decomposition, user stories, verification plans, and architecture/dependency/Mermaid diagrams",
+  "version": "1.0.0",
+  "author": {
+    "name": "Britt Crawford",
+    "email": "britt@brittcrawford.com"
+  },
+  "homepage": "https://github.com/britt/claude-code-skills",
+  "repository": "https://github.com/britt/claude-code-skills",
+  "license": "MIT",
+  "keywords": ["bundle", "planning", "setup", "user-stories", "diagrams", "verification", "issues"]
+}

--- a/bundles/project-foundations/skills/architecture-diagramming
+++ b/bundles/project-foundations/skills/architecture-diagramming
@@ -1,0 +1,1 @@
+../../../skills/architecture-diagramming

--- a/bundles/project-foundations/skills/dependency-mapping
+++ b/bundles/project-foundations/skills/dependency-mapping
@@ -1,0 +1,1 @@
+../../../skills/dependency-mapping

--- a/bundles/project-foundations/skills/issue-decomposition
+++ b/bundles/project-foundations/skills/issue-decomposition
@@ -1,0 +1,1 @@
+../../../skills/issue-decomposition

--- a/bundles/project-foundations/skills/mermaid-diagrams
+++ b/bundles/project-foundations/skills/mermaid-diagrams
@@ -1,0 +1,1 @@
+../../../skills/mermaid-diagrams

--- a/bundles/project-foundations/skills/setting-up-a-project
+++ b/bundles/project-foundations/skills/setting-up-a-project
@@ -1,0 +1,1 @@
+../../../skills/setting-up-a-project

--- a/bundles/project-foundations/skills/user-story-template
+++ b/bundles/project-foundations/skills/user-story-template
@@ -1,0 +1,1 @@
+../../../skills/user-story-template

--- a/bundles/project-foundations/skills/writing-user-stories
+++ b/bundles/project-foundations/skills/writing-user-stories
@@ -1,0 +1,1 @@
+../../../skills/writing-user-stories

--- a/bundles/project-foundations/skills/writing-verification-plans
+++ b/bundles/project-foundations/skills/writing-verification-plans
@@ -1,0 +1,1 @@
+../../../skills/writing-verification-plans


### PR DESCRIPTION
Adds a new curated bundle plugin, `project-foundations`, that groups eight skills for taking a new project from concept to a diagrammed, story-driven plan: `setting-up-a-project`, `issue-decomposition`, `user-story-template`, `writing-user-stories`, `writing-verification-plans`, `architecture-diagramming`, `dependency-mapping`, and `mermaid-diagrams`. Each skill is single-sourced via relative symlinks back to the canonical `skills/` directories rather than duplicating content. Registers the plugin in `marketplace.json` (bumped to 1.5.0) and documents the `/plugin install project-foundations@britt` install path in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)