### PR TITLE
docs(site): sync documentation site with recent skill overhaul and bundles

### DIFF
--- a/.doc.holiday/styleguide.md
+++ b/.doc.holiday/styleguide.md
@@ -67,11 +67,35 @@ This is the **source of truth** for all skills. Each skill lives in its own subd
 **Available Skills:**
 | Skill | Purpose |
 |-------|---------|
-| `daily-planning-ritual` | Interactive morning planning across life dimensions |
+| `sgai-goal` | Composes GOAL.md files for SGAI workspaces |
 | `setting-up-a-project` | Authors CLAUDE.md project documentation |
+| `working-on-an-issue` | Implements a GitHub issue with a verification-driven approach |
+| `project-analysis` | Analyzes project codebase structure, architecture, and dependencies |
+| `project-planning` | Orchestrates end-to-end project planning |
+| `issue-decomposition` | Decomposes projects into well-structured GitHub issues |
+| `dependency-mapping` | Generates Mermaid dependency graphs for issues |
+| `timeline-planning` | Generates Mermaid Gantt charts for project timelines |
+| `requirement-elicitation` | Conversational wizard for eliciting requirements |
+| `idea-to-design` | Turns an idea note into a design document |
 | `writing-product-specs` | Creates comprehensive product specifications |
-| `writing-user-stories` | Generates properly formatted user stories |
+| `writing-user-stories` | Generates properly formatted user stories (INVEST, Given-When-Then) |
 | `writing-verification-plans` | Creates acceptance testing procedures |
+| `context-aware-questions` | Identifies information gaps and generates questions |
+| `at-risk-detection` | Identifies at-risk issues and PRs |
+| `triage-new-issues` | Reviews and prioritizes new GitHub issues |
+| `stakeholder-tracking` | Tracks stakeholder personas and goals |
+| `stakeholder-updates` | Crafts stakeholder communications |
+| `prepare-meeting-agenda` | Generates meeting agendas from issues and PRs |
+| `architecture-diagramming` | Generates Mermaid architecture diagrams |
+| `mermaid-diagrams` | Guide for syntactically correct Mermaid diagrams |
+| `markdown-formatting` | Formats AI outputs into consistent Markdown |
+| `build-faq-from-issues` | Extracts an FAQ from closed GitHub issues |
+| `summarize-conversation-thread` | Summarizes GitHub issue/PR threads |
+| `consolidate-notes-summary` | Synthesizes findings across multiple notes |
+| `research-topic-summarize` | Researches topics via web search |
+| `daily-planning-ritual` | Interactive morning planning across life dimensions |
+
+Also see `bundles/project-foundations/` — a curated bundle plugin that groups related skills (setup, issue decomposition, user stories, verification plans, and diagrams) via symlinks back to the canonical `skills/` directories.
 
 ### `/site/` - GitHub Pages Site
 

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -9,7 +9,9 @@ description: "Claude Skills are reusable instruction sets that give Claude struc
 
 | Skill | Description | Claude Code | Claude.ai |
 |-------|-------------|:-----------:|:---------:|
+| [SGAI Goal Authoring](./skills/sgai-goal/) | Compose GOAL.md files for SGAI workspaces through interactive conversation. | ✓ | |
 | [Setting Up a Project](./skills/setting-up-a-project/) | Authors a CLAUDE.md file that defines your project's purpose, tech stack, and development practices before any code is written. | ✓ | |
+| [Working on an Issue](./skills/working-on-an-issue/) | Implement a GitHub issue with a repeatable, verification-driven approach. | ✓ | |
 | [Project Analysis](./skills/project-analysis/) | Analyze a project's codebase structure, architecture, key files, and dependencies. | ✓ | ✓ |
 | [Project Planning](./skills/project-planning/) | Orchestrate end-to-end project planning with issues, architecture diagrams, dependency maps, and timelines. | ✓ | ✓ |
 | [Issue Decomposition](./skills/issue-decomposition/) | Decompose projects into well-structured GitHub issues with user stories, acceptance criteria, and estimates. | ✓ | ✓ |
@@ -62,7 +64,18 @@ description: "Claude Skills are reusable instruction sets that give Claude struc
 ```bash
 # Add the marketplace
 /plugin marketplace add britt/claude-code-skills
+
+# Install everything
+/plugin install claude-code-skills@britt
 ```
+
+### Curated Bundles
+
+Bundles group related skills for a common workflow instead of installing everything.
+
+| Bundle | Includes | Install |
+|--------|----------|---------|
+| [Project Foundations](./skills/project-foundations/) | Setup, issue decomposition, user stories, verification plans, and architecture/dependency/Mermaid diagrams | `/plugin install project-foundations@britt` |
 
 ### Manual Installation
 

--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -17,6 +17,21 @@ The easiest way to install skills in Claude Code:
 /plugin marketplace add britt/claude-code-skills
 ```
 
+Once the marketplace is added, install everything, a curated bundle, or a single skill:
+
+```bash
+# Install all skills
+/plugin install claude-code-skills@britt
+
+# Install a curated bundle (e.g. project-foundations)
+/plugin install project-foundations@britt
+
+# Install a single skill
+/plugin install setting-up-a-project@britt
+```
+
+See the [Skills](../skills/) page for the full list of individual skills and bundles.
+
 ### Global Installation
 
 Install skills globally so they're available in all projects:

--- a/site/content/skills/architecture-diagramming.md
+++ b/site/content/skills/architecture-diagramming.md
@@ -3,7 +3,7 @@ title: "Architecture Diagramming"
 description: "Generate Mermaid architecture diagrams showing system components, layers, and data flows"
 ---
 
-Create clear, GitHub-compatible Mermaid architecture diagrams that visualize system components, layers, boundaries, and data flows. Whether you need a system overview, layered architecture, request flow, or microservices diagram, this skill produces well-structured Mermaid syntax that renders correctly on GitHub.
+Create clear, GitHub-compatible Mermaid architecture diagrams that visualize system components, layers, boundaries, and data flows. Whether you need a system overview, layered architecture, or request flow diagram, this skill produces well-structured Mermaid syntax that renders correctly on GitHub.
 
 ### Installation
 
@@ -33,12 +33,12 @@ Use this skill when:
 - You need an architecture diagram for your system
 - You want to visualize how components interact
 - During project planning to communicate system design
-- Explaining layered architecture, request flows, or microservices layouts
+- Explaining layered architecture or request flows
 
 ## Features
 
 **Multiple diagram patterns**
-Supports system overviews, layered architectures, request flows, and microservices diagrams with subgraphs for clear boundaries.
+Supports system overviews, layered architectures, and request flows, with subgraphs for clear boundaries.
 
 **GitHub-safe Mermaid syntax**
 Follows strict syntax rules to avoid rendering errors, including never using parentheses inside labels and always ensuring matching brackets.

--- a/site/content/skills/at-risk-detection.md
+++ b/site/content/skills/at-risk-detection.md
@@ -47,4 +47,7 @@ Produces a project health summary with total open items, at-risk counts, health 
 For each risk signal detected, provides specific recommendations such as commenting with status updates, resolving blocking dependencies, or redistributing overloaded assignees.
 
 **Quick and comprehensive modes**
-Quick mode scans the 30 most recent open issues for daily checks; comprehensive mode paginates through all open issues for thorough milestone reviews.
+Quick mode scans the 30 most recent open issues for daily checks; comprehensive mode paginates through all open issues for thorough milestone reviews. Because quick mode sorts by recency, it can miss the stalest items — the report calls this out, and comprehensive mode should be used to find them.
+
+**Common-mistake guardrails**
+Avoids known false positives: draft PRs aren't flagged as stale-awaiting-review, and issues intentionally parked with an `on-hold` label are reported separately from genuinely forgotten stale work.

--- a/site/content/skills/build-faq-from-issues.md
+++ b/site/content/skills/build-faq-from-issues.md
@@ -29,11 +29,15 @@ Or install all skills at once:
 
 ## How to use it
 
+Requires the `gh` CLI authenticated to the target repository.
+
 Use this skill when:
 - Creating or updating a project FAQ
 - Documenting common support questions to reduce repeat issues
 - Onboarding new users or contributors
 - Building support documentation from past issues
+
+Not a fit for open-issue triage, changelogs or release notes, or repos with too few closed issues to reveal recurring patterns.
 
 ## Features
 

--- a/site/content/skills/context-aware-questions.md
+++ b/site/content/skills/context-aware-questions.md
@@ -38,7 +38,7 @@ Use this skill when:
 ## Features
 
 **Multiple analysis modes**
-Supports project-wide reviews, individual issue reviews, draft reviews before submission, and documentation gap analysis.
+Supports project-wide reviews, individual issue reviews, draft reviews before submission, and documentation gap analysis. Issue-based modes fetch data via the `gh` CLI, which must be installed and authenticated.
 
 **Gap detection heuristics**
 Automatically detects missing acceptance criteria, vague descriptions, missing labels or assignees, stale issues, bug reports without reproduction steps, and incomplete documentation.

--- a/site/content/skills/daily-planning-ritual.md
+++ b/site/content/skills/daily-planning-ritual.md
@@ -37,7 +37,7 @@ You can trigger this skill with phrases like:
 ## Features
 
 **Context gathering across your life**
-Gathers context from your calendar, emails, and static sections so your plan reflects real constraints.
+Gathers context from your calendar, reminders, emails, and Drive docs, plus persistent sections from a `Daily Planning Notes` Google Doc, so your plan reflects real constraints. Requires Google Calendar, Gmail, Google Drive, and Reminders connectors; any unavailable source is skipped and noted in the plan.
 
 **Conversational planning workflow**
 Leads a reflective, conversational workflow across life dimensions including work, fitness, relationship, social, and adventure.

--- a/site/content/skills/dependency-mapping.md
+++ b/site/content/skills/dependency-mapping.md
@@ -48,3 +48,5 @@ Groups issues into logical phases using Mermaid subgraphs for clear visual separ
 
 **Multiple graph layouts**
 Supports linear dependencies (left-to-right), parallel work (top-to-bottom), and complex multi-branch layouts with consistent issue node naming conventions.
+
+Requires the `gh` CLI (or an equivalent GitHub MCP server) to gather issue data.

--- a/site/content/skills/issue-decomposition.md
+++ b/site/content/skills/issue-decomposition.md
@@ -48,3 +48,6 @@ Uses a consistent label system for type, area, and priority, with T-shirt sizing
 
 **Preview before creating**
 Always shows a summary table of proposed issues with titles, estimates, and dependencies before creating anything in GitHub.
+
+**Worked example included**
+Includes a sample decomposition of "Build a user authentication system" into 7 dependency-linked issues, showing exactly what the output looks like.

--- a/site/content/skills/markdown-formatting.md
+++ b/site/content/skills/markdown-formatting.md
@@ -33,7 +33,9 @@ Use this skill when:
 - Writing PR descriptions or issue bodies
 - Producing documentation and guides
 - Creating notes and summaries
-- Formatting any structured text output for consistency
+- Producing structured artifacts that will be saved or published, such as reports, READMEs, or changelogs
+
+Not for conversational chat replies — normal responses don't need templates or strict formatting rules.
 
 ## Features
 
@@ -41,7 +43,7 @@ Use this skill when:
 Every document starts with a TL;DR or summary, followed by details. Headings, lists, and whitespace are used to aid scanning.
 
 **Context-aware templates**
-Provides ready-made templates for PR descriptions (with summary, changes, and test plan) and issue bodies (with problem, steps to reproduce, expected, and actual).
+Provides ready-made templates for PR descriptions (with summary, changes, and test plan) and issue bodies (with problem, steps to reproduce, expected, and actual), plus a filled-in example PR description showing the rules applied.
 
 **Consistent formatting rules**
 Enforces dash-style unordered lists, numbered ordered lists, language-identified code blocks, proper heading hierarchy, and descriptive link text.

--- a/site/content/skills/mermaid-diagrams.md
+++ b/site/content/skills/mermaid-diagrams.md
@@ -31,9 +31,10 @@ Or install all skills at once:
 
 Use this skill when:
 - Creating flowcharts, sequence diagrams, or class diagrams
-- Visualizing API flows, decision trees, or system architecture
+- Visualizing API flows or decision trees
 - Building entity relationship diagrams or state machines
 - Adding any visual diagram to Markdown documentation
+- A Mermaid diagram fails to render on GitHub and needs its syntax fixed
 
 ## Features
 
@@ -44,7 +45,7 @@ Covers flowcharts, sequence diagrams, class diagrams, state diagrams, entity rel
 Strictly avoids parentheses inside labels and ensures matching brackets on all node shapes, preventing the most common Mermaid rendering errors.
 
 **Common pattern library**
-Includes ready-to-use patterns for API flows, decision flows, and system architecture diagrams that can be adapted to your specific needs.
+Includes ready-to-use patterns for API flows and decision flows that can be adapted to your specific needs. For system architecture diagrams (components, layers, data flows), use the `architecture-diagramming` skill instead.
 
 **Complete syntax reference**
 Provides a reference for node shapes, arrow types, and styling options so you can customize diagrams without consulting external documentation.

--- a/site/content/skills/project-foundations.md
+++ b/site/content/skills/project-foundations.md
@@ -1,0 +1,38 @@
+---
+title: "Project Foundations (Bundle)"
+description: "A curated bundle for taking a new project from concept to a diagrammed, story-driven plan"
+---
+
+A curated bundle for taking a new project from concept to a diagrammed, story-driven plan: project setup, issue decomposition, user stories, verification plans, and architecture/dependency/Mermaid diagrams.
+
+### Installation
+
+Add the marketplace and install the bundle:
+
+```bash
+/plugin marketplace add britt/claude-code-skills
+/plugin install project-foundations@britt
+```
+
+## Compatibility
+
+| Platform | Supported |
+|----------|:---------:|
+| Claude Code | ✓ |
+| Claude.ai | |
+
+## Included Skills
+
+| Skill | Description |
+|-------|-------------|
+| [Setting Up a Project](./setting-up-a-project/) | Authors a CLAUDE.md file that defines your project's purpose, tech stack, and development practices before any code is written. |
+| [Issue Decomposition](./issue-decomposition/) | Decompose projects into well-structured GitHub issues with user stories, acceptance criteria, and estimates. |
+| [Writing User Stories](./writing-user-stories/) | Write properly formatted user stories with Given-When-Then acceptance criteria and an INVEST quality checklist. |
+| [Writing Verification Plans](./writing-verification-plans/) | Create verification plans for real-world acceptance testing with concrete scenarios and success criteria. |
+| [Architecture Diagramming](./architecture-diagramming/) | Generate Mermaid architecture diagrams showing system components, layers, and data flows. |
+| [Dependency Mapping](./dependency-mapping/) | Generate Mermaid dependency graphs showing issue relationships, blocking chains, and critical paths. |
+| [Mermaid Diagrams](./mermaid-diagrams/) | Guide for creating syntactically correct Mermaid diagrams that render properly on GitHub. |
+
+## How to use it
+
+Install the bundle when you want the full concept-to-plan workflow in one step rather than installing each skill individually. Each skill in the bundle is single-sourced back to its canonical definition under `skills/`, so bundle and standalone installs always stay in sync.

--- a/site/content/skills/project-planning.md
+++ b/site/content/skills/project-planning.md
@@ -38,13 +38,13 @@ Use this skill when:
 ## Features
 
 **End-to-end planning orchestration**
-Coordinates issue decomposition, architecture diagramming, dependency mapping, and timeline planning into a single workflow from description to saved plan.
+Coordinates issue decomposition, architecture diagramming, dependency mapping, and timeline planning into a single workflow from description to saved plan. These run as sub-skills (installed individually or via the project-foundations bundle); if one isn't available, this skill performs that step inline instead.
 
 **Discovery-first approach**
 Starts by asking clarifying questions about project goals, technical context, and constraints, and analyzes the existing codebase before generating any artifacts.
 
 **Preview before creation**
-Shows a complete preview of all proposed issues, architecture diagram, dependency graph, and Gantt chart for review before creating anything in GitHub.
+Shows a complete preview of all proposed issues, architecture diagram, dependency graph, and Gantt chart for review before creating anything in GitHub. Issues are created with the `gh` CLI or an available GitHub MCP tool; if neither is available, it outputs the issue bodies for manual creation instead.
 
 **Persistent planning documents**
 Saves a comprehensive planning document with overview, goals, architecture, dependency graph, timeline, risks, and issue listing to the project for future reference.

--- a/site/content/skills/research-topic-summarize.md
+++ b/site/content/skills/research-topic-summarize.md
@@ -35,6 +35,8 @@ Use this skill when:
 - Comparing options (X vs Y) to make a decision
 - Gathering background information for a technical or business decision
 
+Skip it for questions answerable directly from local docs or code, and prefer a dedicated deep-research capability (if available) for deep, multi-source fact-checked reports.
+
 ## Features
 
 **Structured research output**

--- a/site/content/skills/setting-up-a-project.md
+++ b/site/content/skills/setting-up-a-project.md
@@ -3,7 +3,7 @@ title: "Setting Up a Project"
 description: "Author CLAUDE.md with project purpose, tech stack, and development practices"
 ---
 
-Author a CLAUDE.md file that defines your project's purpose, tech stack, and development practices before any code is written. It uses brainstorming to clarify goals, choose a tech stack, and establish development conventions before scaffolding code.
+Author a CLAUDE.md file that defines your project's purpose, tech stack, and development practices before any code is written. It interviews you one question at a time to clarify goals, choose a tech stack, and establish development conventions before scaffolding code.
 
 ### Installation
 
@@ -36,14 +36,14 @@ Use this skill when:
 
 ## Features
 
-**Brainstorming-driven project definition**
-Uses a brainstorming workflow to define the project's purpose and align on what you are building.
+**Guided interview for project definition**
+Asks one question at a time to define the project's purpose and align on what you are building, rather than dumping questions all at once.
 
 **Tech stack with sensible defaults**
 Establishes the tech stack with sensible defaults so you have a clear starting point.
 
 **Development practices and git workflow**
-Copies test-driven development rules and git practices (including "commit early, commit often") into CLAUDE.md.
+Copies test-driven development rules and git practices (including "commit early, commit often") verbatim into CLAUDE.md, along with pull request rules covering merge commits and issue-closing references.
 
 **Verification plan integration**
 Creates a verification plan by invoking the Writing Verification Plans skill.

--- a/site/content/skills/sgai-goal.md
+++ b/site/content/skills/sgai-goal.md
@@ -1,0 +1,58 @@
+---
+title: "SGAI Goal Authoring"
+description: "Compose GOAL.md files for SGAI workspaces through interactive conversation"
+---
+
+Compose GOAL.md files for SGAI workspaces through interactive conversation. This skill detects your tech stack, selects the right developer and reviewer agents, and interviews you to build a complete goal file with an agent flow graph, model preferences, a completion gate, and outcome-based success criteria.
+
+### Installation
+
+Add the marketplace and install this skill:
+
+```bash
+/plugin marketplace add britt/claude-code-skills
+/plugin install sgai-goal@britt
+```
+
+Or install all skills at once:
+
+```bash
+/plugin install claude-code-skills@britt
+```
+
+## Compatibility
+
+| Platform | Supported |
+|----------|:---------:|
+| Claude Code | ✓ |
+| Claude.ai | |
+
+## How to use it
+
+Use this skill when:
+
+- Starting a new feature, project, or bug fix in a repository that uses SGAI
+- Asked to "create a goal" or "set up SGAI"
+- Describing work to be done in an SGAI-managed repo
+
+The skill first checks for an `.sgai/` directory (or other SGAI configuration) and stops to confirm with you if it can't find one.
+
+## Features
+
+**Automatic tech stack detection**
+Scans the repository for `go.mod`, `package.json`, `wrangler.toml`, `vercel.json`, and other indicators to choose the right developer and reviewer agent pairing — Go, React, HTMX, shell/CLI, Cloudflare Workers, Vercel, and Agent SDK stacks are all recognized, and multiple stacks combine into a single flow.
+
+**Model preference memory**
+Reads saved model preferences from `.sgai/preferences.json`, or asks once and saves the answer for future goals.
+
+**Outcome-based success criteria**
+Turns a plain description of the work into checklist-style success criteria that describe outcomes ("users can sign in with OAuth providers") rather than implementation steps.
+
+**Agent flow graph composition**
+Builds the `developer -> reviewer -> stpa-analyst` flow graph for the detected stack, always terminating in `stpa-analyst` for safety analysis except in pure documentation flows.
+
+**Completion gate detection**
+Infers a `completionGateScript` from the project's test tooling (`go test ./...`, `npm test`, `make test`) so SGAI knows how to verify the goal is done.
+
+**Safe overwrite handling**
+If a `GOAL.md` already exists, it is renamed to a timestamped backup before the new one is written — no work is lost.

--- a/site/content/skills/timeline-planning.md
+++ b/site/content/skills/timeline-planning.md
@@ -48,3 +48,6 @@ Marks key deliverables as milestones and highlights the critical path using Merm
 
 **Parallel workstream visualization**
 Supports multiple concurrent workstreams with proper integration points, showing where parallel work converges and how it affects the overall timeline.
+
+**Reusable Gantt patterns**
+Ships with a library of ready-made chart templates — linear projects, parallel workstreams, milestone-driven releases, and critical-path layouts — so common timeline shapes don't need to be built from scratch.

--- a/site/content/skills/writing-product-specs.md
+++ b/site/content/skills/writing-product-specs.md
@@ -30,5 +30,23 @@ Or install all skills at once:
 ## How to use it
 
 Use this skill when:
-- Designing a new feature
-- Asked to write a product spec or PRD
+- You're asked to write a product spec, product requirements document, or PRD
+- You're designing a new feature and need to document requirements before implementation
+- You're planning a project and need to define what will be built and why
+- You need to communicate product requirements to stakeholders, engineers, or designers
+- A feature request needs to be expanded into a detailed specification with context, requirements, and success criteria
+- You need to document the "what" and "why" of a product decision before moving to implementation
+
+## Features
+
+**Guided elicitation**
+Asks targeted questions to surface the problem, audience, pain points, proposed solution, success and failure criteria, and explicit non-goals before drafting begins.
+
+**Structured spec template**
+Drafts follow a consistent template covering Background (context, audience, problem statements), Hypothesis, Success Criteria, Requirements, Non-requirements, and Tradeoffs and Concerns, so every spec is complete and easy to review.
+
+**Iterative refinement**
+Presents the full draft, then revises based on your feedback until you confirm the spec is accurate and complete.
+
+**Ready-to-save output**
+Saves the finished spec as a markdown file named `spec-<feature-name>-MM-DD-YYYY.md`, or wherever you'd like it.

--- a/site/content/skills/writing-user-stories.md
+++ b/site/content/skills/writing-user-stories.md
@@ -3,7 +3,7 @@ title: "Writing User Stories"
 description: "Write properly formatted user stories for task definition"
 ---
 
-Write properly formatted user stories that identify the persona, desired action, and expected benefit so you can turn product ideas into clear, testable work items.
+Write properly formatted user stories that identify the persona, desired action, and expected benefit, complete with Given-When-Then acceptance criteria and an INVEST quality check, so you can turn product ideas into clear, testable work items.
 
 ### Installation
 
@@ -31,4 +31,20 @@ Or install all skills at once:
 
 Use this skill when:
 - Asked to write user stories
-- Planning a feature
+- Defining requirements
+- Breaking a feature into stories
+- Drafting product or feature issues for GitHub
+
+## Features
+
+**"As a / I want / so that" format**
+Every story identifies the persona, the desired action, and the benefit, keeping requirements consistent and easy to scan.
+
+**Given-When-Then acceptance criteria**
+Each story gets clear, testable conditions in Given-When-Then format, preventing scope creep and unclear definitions of done.
+
+**INVEST quality checklist**
+Before a story is finalized, it's checked against INVEST (Independent, Negotiable, Valuable, Estimable, Small, Testable) to catch stories that are too vague, too large, or hard to test.
+
+**Common pitfalls guidance**
+Flags stories that are too technical, too vague, or missing the "why," with before/after examples to guide corrections.

--- a/site/content/skills/writing-verification-plans.md
+++ b/site/content/skills/writing-verification-plans.md
@@ -30,8 +30,9 @@ Or install all skills at once:
 ## How to use it
 
 Use this skill when:
-- Setting up a new project
-- A project needs acceptance testing procedures
+- A project lacks a VERIFICATION_PLAN.md
+- Finishing up after setting up a new project
+- You're asked how to prove a feature works end-to-end
 
 ## Features
 


### PR DESCRIPTION
## Summary

- Add missing site pages for the `sgai-goal` skill and the new `project-foundations` bundle, and link both from the homepage.
- Document bundle installs (`project-foundations`) in the homepage Quick Start and docs page.
- Fix content drift in 19 skill pages left stale by the systematic skill-review refactor (#41): merged `writing-user-stories` content from the removed `user-story-template` skill, removed features (e.g. microservices diagramming), new supporting reference files, and changed workflows.
- Refresh `.doc.holiday/styleguide.md`'s skills table, which only listed 5 of 27 skills.

## Test plan

- [x] `hugo --minify` build confirmed to succeed up to a pre-existing theme/version incompatibility unrelated to this change (verified present on `main` with zero content edits)
- [x] All new/edited frontmatter validated as well-formed YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)