### PR TITLE
refactor(skills): make working-on-an-issue hands-off with scoped recon and PR gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "britt",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A collection of skills for Claude Code to enhance AI-assisted development workflows",
   "owner": {
     "name": "Britt Crawford",
@@ -11,7 +11,7 @@
     {
       "name": "claude-code-skills",
       "description": "All skills bundled together for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "author": {
         "name": "Britt Crawford",
         "email": "britt@brittcrawford.com"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -254,8 +254,8 @@
     },
     {
       "name": "working-on-an-issue",
-      "description": "Guided workflow for reading, understanding, and implementing GitHub issues",
-      "version": "1.1.0",
+      "description": "Hands-off workflow for implementing GitHub issues: scoped recon, verification-first planning, TDD implementation, and a PR that serves as the approval gate",
+      "version": "1.2.0",
       "author": {
         "name": "Britt Crawford"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code-skills",
   "description": "Skills for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": {
     "name": "Britt Crawford",
     "email": "britt@brittcrawford.com"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A collection of skills for Claude to enhance AI-assisted development workflows.
 |-------|-------------|:-----------:|:---------:|
 | **sgai-goal** | Compose GOAL.md files for SGAI workspaces through interactive conversation | * | |
 | **setting-up-a-project** | Author CLAUDE.md with project purpose, tech stack, and development practices | * | |
-| **working-on-an-issue** | Work on, read, or implement a GitHub issue | * | |
+| **working-on-an-issue** | Implement a GitHub issue hands-off, with scoped recon and a PR as the approval gate | * | |
 | **project-analysis** | Analyze project codebase structure, architecture, key files, and dependencies | * | * |
 | **project-planning** | Orchestrate end-to-end project planning with issues, diagrams, dependencies, and timelines | * | * |
 | **issue-decomposition** | Decompose projects into well-structured GitHub issues with user stories and estimates | * | * |

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -11,7 +11,7 @@ description: "Claude Skills are reusable instruction sets that give Claude struc
 |-------|-------------|:-----------:|:---------:|
 | [SGAI Goal Authoring](./skills/sgai-goal/) | Compose GOAL.md files for SGAI workspaces through interactive conversation. | ✓ | |
 | [Setting Up a Project](./skills/setting-up-a-project/) | Authors a CLAUDE.md file that defines your project's purpose, tech stack, and development practices before any code is written. | ✓ | |
-| [Working on an Issue](./skills/working-on-an-issue/) | Implement a GitHub issue with a repeatable, verification-driven approach. | ✓ | |
+| [Working on an Issue](./skills/working-on-an-issue/) | Implement a GitHub issue hands-off — scoped recon, verification-first planning, and a PR as the single approval gate. | ✓ | |
 | [Project Analysis](./skills/project-analysis/) | Analyze a project's codebase structure, architecture, key files, and dependencies. | ✓ | ✓ |
 | [Project Planning](./skills/project-planning/) | Orchestrate end-to-end project planning with issues, architecture diagrams, dependency maps, and timelines. | ✓ | ✓ |
 | [Issue Decomposition](./skills/issue-decomposition/) | Decompose projects into well-structured GitHub issues with user stories, acceptance criteria, and estimates. | ✓ | ✓ |

--- a/site/content/skills/working-on-an-issue.md
+++ b/site/content/skills/working-on-an-issue.md
@@ -1,9 +1,9 @@
 ---
 title: "Working on an Issue"
-description: "Implement GitHub issues with verification"
+description: "Hands-off implementation of GitHub issues, reviewed at the PR"
 ---
 
-Implement a GitHub issue with a repeatable, verification-driven approach.
+Implement a GitHub issue end to end without mid-flow approval gates: scoped reconnaissance, verification-first planning, TDD implementation, and a pull request that serves as the single review point.
 
 ### Installation
 
@@ -31,29 +31,32 @@ Or install all skills at once:
 
 Use this skill when:
 
-- Asked to work on a GitHub issue
-- Asked to implement an issue
+- Asked to work on or implement a GitHub issue
 - Given an issue URL or issue number
 
 To start, provide the issue URL or number.
 
-Before proceeding, confirm the pre-flight checklist:
+Before proceeding, the agent confirms the pre-flight checklist:
 
 - Issue URL or number obtained
-- Repository cloned and on the correct branch
+- Repository cloned and a work branch created (`issue-<number>-<short-slug>`)
 - `CLAUDE.md` exists (or run `setting-up-a-project` first)
-- A developer is available for questions (or an async mode is explicitly agreed)
+
+Not every issue qualifies. Epic-sized issues that bundle independent changes are routed to `issue-decomposition` first, and issues too vague to restate as testable acceptance criteria are routed to `requirement-elicitation` instead of being implemented on guesswork.
 
 ## Features
 
-**A plan-first approach with explicit approval**
-Writes an implementation plan and saves it to `docs/plans/issue-<number>-plan.md`, then waits for approval before making changes.
+**Hands-off by default — the PR is the approval gate**
+There are no approval checkpoints during the work. Plans are saved to `docs/plans/issue-<number>-plan.md` and implementation proceeds immediately; the developer reviews the finished work on the pull request, where every assumption and verification result is recorded.
 
-**Verification is part of the process (twice)**
-Creates a verification plan up front (via `writing-verification-plans`), then executes the verification plan again after implementation.
+**Scoped reconnaissance with a hard budget**
+Exploration exists to locate the change, not to understand the codebase. The agent starts from identifiers the issue names, expands at most one hop, and stops as soon as it knows which files change, which pattern to follow, and which tests cover the area. If about ten targeted searches don't produce that list, the issue is treated as underspecified and sent back rather than explored harder.
 
-**Rules that reduce scope creep**
-Requires clarification when requirements, acceptance criteria, or boundaries are ambiguous, and avoids inventing requirements that are not in the issue.
+**Verification-first planning**
+The verification plan (via `writing-verification-plans`) is written before the implementation plan, because acceptance criteria define done. After implementation the plan is executed and the results are logged; a PR is never opened with failing verification, and failures are root-caused with systematic debugging rather than patched over.
+
+**Assumptions documented, scope protected**
+Ambiguity is resolved with the narrowest interpretation and recorded in the plan and PR — but assumptions may only resolve *how*, never shrink *what* the issue asks for. `Fixes #<number>` is used only when every named request is addressed; anything split out or deferred is flagged with `Refs #<number>` instead.
 
 **Clear stop conditions**
-When blocked, stops and asks the developer instead of guessing.
+When genuinely blocked — missing credentials, contradictory requirements — the agent comments on the issue and stops instead of guessing through it.

--- a/skills/working-on-an-issue/SKILL.md
+++ b/skills/working-on-an-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: working-on-an-issue
-description: Use when asked to work on, read, or implement a GitHub issue - structured understand, plan, verify, implement, verify workflow with developer approval gates and mandatory verification
+description: Use when asked to work on, read, or implement a GitHub issue - hands-off workflow (understand, scoped recon, verification plan, implementation plan, implement, verify, PR) with no mid-flow approval gates; assumptions are documented in the plan and PR, and developer review happens on the pull request
 ---
 
 # Working on an Issue
@@ -9,67 +9,89 @@ description: Use when asked to work on, read, or implement a GitHub issue - stru
 
 ## Overview
 
-A structured workflow for implementing GitHub issues with verification.
+A hands-off workflow for implementing GitHub issues. There are no approval gates before the pull request: the developer reviews finished work on the PR, so every judgment call you make must be recorded where they will see it.
 
-**Core Principle:** Understand → Plan → Verify → Implement → Verify Again
+**Core principle:** Understand → Recon → Plan verification → Plan implementation → Implement → Verify → PR
+
+**Create TodoWrite todos for the pre-flight checklist and each numbered step below.**
 
 ## When to Use
 
-- Developer asks to work on a GitHub issue
-- Developer asks to implement an issue
+- Developer asks to work on or implement a GitHub issue
 - Developer provides an issue URL or number
+
+## When NOT to Use
+
+- Issue is epic-sized or bundles multiple independent changes → run `issue-decomposition` first
+- Issue is too vague to restate as testable acceptance criteria → run `requirement-elicitation`, or comment on the issue with your questions, and stop
+- Triaging or labeling incoming issues → `triage-new-issues`
 
 ## Pre-flight Checklist
 
-Before starting:
 - [ ] Issue URL or number obtained
-- [ ] Repository cloned and on correct branch
+- [ ] Repository cloned; work branch created: `issue-<number>-<short-slug>`
 - [ ] CLAUDE.md exists (or run `setting-up-a-project` first)
-- [ ] Developer available for questions (or async mode agreed)
 
 ## The Process
 
-### 1. Read and Understand the Issue
+### 1. Read the Whole Issue
 
-Get the issue content via:
-- GitHub CLI: `gh issue view <number>`
-- Ask user to paste the issue content
-- Use GitHub MCP tools if available
+Get the issue **and its comments**: `gh issue view <number> --comments` (or GitHub MCP tools, or ask for pasted content). Comments often supersede the body — the latest clarification wins. Check for linked or duplicate PRs already addressing it.
 
-**Clarify before proceeding:**
-- If requirements are ambiguous, ask specific questions
-- If acceptance criteria are missing, propose them
-- If scope is unclear, confirm boundaries
+**Sizing check:** restate the issue as 1–5 testable acceptance criteria. If you can't, take the off-ramp in When NOT to Use instead of proceeding.
 
-**Do not assume or invent requirements not in the issue.**
+Do not invent requirements. Where the issue is ambiguous, choose the narrowest interpretation that satisfies the text and record it as an assumption — assumptions go in the plan file and the PR description, never unstated.
 
-### 2. Write an Implementation Plan
+**Assumptions resolve ambiguity in *how*, never reduce *what* the issue asks for.** Dropping a named request ("deferred the tour") is not an assumption — it's a scope cut, and scope cuts go through `issue-decomposition`, not the assumptions list. Manufacturing acceptance criteria the issue never stated to pass the sizing check is the same violation.
 
-Use the `superpowers:writing-plans` skill (if available) or create a brief plan covering:
-1. What changes are needed
-2. Which files will be modified/created
-3. Order of implementation
-4. Risks or unknowns
+### 2. Scoped Reconnaissance
 
-Save to `docs/plans/issue-<number>-plan.md` and get developer approval before proceeding.
+The issue bounds the exploration. Recon exists to *locate the change*, not to understand the codebase.
 
-### 3. Write a Verification Plan
+Stop exploring the moment you can answer all three:
+1. Which files will change?
+2. Which existing pattern or convention will the change follow?
+3. Which tests cover this area?
 
-Use the `writing-verification-plans` skill to create acceptance tests for the issue.
+**Budget:** start from files, symbols, and error messages the issue names; expand at most one hop (direct callers/callees and their tests). Check callers only to confirm the fix won't break them, then stop — "who uses this everywhere and how" is an architecture survey, not recon. If roughly 10 targeted searches haven't produced the file list, more exploration will not fix it — the issue is underspecified; take the off-ramp.
 
-### 4. Implement
+**Forbidden:** reading whole directories "for context", tracing beyond one hop, architecture surveys.
+
+### 3. Write the Verification Plan
+
+Use the `writing-verification-plans` skill. This comes before the implementation plan because acceptance criteria define done and constrain the implementation.
+
+### 4. Write the Implementation Plan
+
+Use `superpowers:writing-plans` (if available) or write a brief plan covering: what changes, which files, order of implementation, risks, and the assumptions from step 1. Save to `docs/plans/issue-<number>-plan.md`, then proceed — do not wait for approval.
+
+### 5. Implement
 
 - Follow TDD practices if `TDD.rules.md` is present (a project-level TDD rules file, if the repo defines one)
-- Commit after each logical change
-- Pause and ask if you hit unexpected complexity
+- Commit after each logical change; reference the issue in commit messages (e.g. `fix: handle empty input (#123)`)
+- Unexpected complexity that invalidates the plan → update the plan file and note it for the PR description
+- Genuinely blocked (missing credentials, contradictory requirements) → comment on the issue and stop
 
-### 5. Execute Verification
+### 6. Execute Verification
 
-Run the verification plan. Report results using the verification log format from the `writing-verification-plans` skill.
+Run the verification plan and record results in the log format from `writing-verification-plans`.
+
+**If verification fails:** use `superpowers:systematic-debugging` to find the root cause — do not patch symptoms — then fix, re-run, and update the log. Never open the PR with failing verification (`superpowers:verification-before-completion` applies).
+
+### 7. Open the Pull Request
+
+Push the branch and create the PR: `gh pr create`. The PR body must include:
+
+- `Fixes #<number>` so merging closes the issue — only if every named request in the issue is addressed; if anything was split out or deferred, use `Refs #<number>` and say what remains open
+- Summary of the change
+- Assumptions made (from the plan)
+- Verification log results
+
+**The PR is the approval gate.** Everything a reviewer needs to judge the work goes in it.
 
 ## Absolute Rules
 
-- **No assumptions**: Ask if anything is unclear
 - **No scope creep**: Only implement what's specified
-- **Verification required**: Task is incomplete until verification passes or developer confirms manual verification
-- **Blocked = Stop**: If blocked, stop and ask the developer — do not guess.
+- **Assumptions documented, never silent**: Narrowest reasonable interpretation, recorded in plan and PR
+- **Verification before PR**: The task is incomplete until verification passes
+- **Blocked = comment and stop**: Comment on the issue and stop — do not guess through contradictions


### PR DESCRIPTION
Closes #50.

Reworks the `working-on-an-issue` skill into a hands-off workflow: no approval gates before the pull request (the PR is the single review point), a budgeted reconnaissance step that stops as soon as the change is located, the verification plan written before the implementation plan, sizing off-ramps to `issue-decomposition`/`requirement-elicitation`, and a final PR-creation step that closes the issue. The rewrite was pressure-tested with subagent scenarios per `writing-skills`, and the two loopholes that surfaced are closed: assumptions may resolve *how* but never shrink *what* the issue asks for, and `Fixes #N` is only allowed when every named request is addressed. Also syncs the marketplace entry (description + 1.2.0 bump), the site page and index row, and the README table, and bumps the claude-code-skills plugin and marketplace to 3.1.0 so installed plugins pick up the change.

Note for merging: use a merge commit, do not squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)