### PR TITLE
Add multi-tool skill discovery for Codex CLI, OpenCode, and Cursor

### DIFF
--- a/.agents/skills/architecture-diagramming
+++ b/.agents/skills/architecture-diagramming
@@ -1,0 +1,1 @@
+../../skills/architecture-diagramming

--- a/.agents/skills/at-risk-detection
+++ b/.agents/skills/at-risk-detection
@@ -1,0 +1,1 @@
+../../skills/at-risk-detection

--- a/.agents/skills/build-faq-from-issues
+++ b/.agents/skills/build-faq-from-issues
@@ -1,0 +1,1 @@
+../../skills/build-faq-from-issues

--- a/.agents/skills/consolidate-notes-summary
+++ b/.agents/skills/consolidate-notes-summary
@@ -1,0 +1,1 @@
+../../skills/consolidate-notes-summary

--- a/.agents/skills/context-aware-questions
+++ b/.agents/skills/context-aware-questions
@@ -1,0 +1,1 @@
+../../skills/context-aware-questions

--- a/.agents/skills/daily-planning-ritual
+++ b/.agents/skills/daily-planning-ritual
@@ -1,0 +1,1 @@
+../../skills/daily-planning-ritual

--- a/.agents/skills/dependency-mapping
+++ b/.agents/skills/dependency-mapping
@@ -1,0 +1,1 @@
+../../skills/dependency-mapping

--- a/.agents/skills/idea-to-design
+++ b/.agents/skills/idea-to-design
@@ -1,0 +1,1 @@
+../../skills/idea-to-design

--- a/.agents/skills/issue-decomposition
+++ b/.agents/skills/issue-decomposition
@@ -1,0 +1,1 @@
+../../skills/issue-decomposition

--- a/.agents/skills/markdown-formatting
+++ b/.agents/skills/markdown-formatting
@@ -1,0 +1,1 @@
+../../skills/markdown-formatting

--- a/.agents/skills/mermaid-diagrams
+++ b/.agents/skills/mermaid-diagrams
@@ -1,0 +1,1 @@
+../../skills/mermaid-diagrams

--- a/.agents/skills/prepare-meeting-agenda
+++ b/.agents/skills/prepare-meeting-agenda
@@ -1,0 +1,1 @@
+../../skills/prepare-meeting-agenda

--- a/.agents/skills/project-analysis
+++ b/.agents/skills/project-analysis
@@ -1,0 +1,1 @@
+../../skills/project-analysis

--- a/.agents/skills/project-planning
+++ b/.agents/skills/project-planning
@@ -1,0 +1,1 @@
+../../skills/project-planning

--- a/.agents/skills/requirement-elicitation
+++ b/.agents/skills/requirement-elicitation
@@ -1,0 +1,1 @@
+../../skills/requirement-elicitation

--- a/.agents/skills/research-topic-summarize
+++ b/.agents/skills/research-topic-summarize
@@ -1,0 +1,1 @@
+../../skills/research-topic-summarize

--- a/.agents/skills/setting-up-a-project
+++ b/.agents/skills/setting-up-a-project
@@ -1,0 +1,1 @@
+../../skills/setting-up-a-project

--- a/.agents/skills/sgai-goal
+++ b/.agents/skills/sgai-goal
@@ -1,0 +1,1 @@
+../../skills/sgai-goal

--- a/.agents/skills/stakeholder-tracking
+++ b/.agents/skills/stakeholder-tracking
@@ -1,0 +1,1 @@
+../../skills/stakeholder-tracking

--- a/.agents/skills/stakeholder-updates
+++ b/.agents/skills/stakeholder-updates
@@ -1,0 +1,1 @@
+../../skills/stakeholder-updates

--- a/.agents/skills/summarize-conversation-thread
+++ b/.agents/skills/summarize-conversation-thread
@@ -1,0 +1,1 @@
+../../skills/summarize-conversation-thread

--- a/.agents/skills/timeline-planning
+++ b/.agents/skills/timeline-planning
@@ -1,0 +1,1 @@
+../../skills/timeline-planning

--- a/.agents/skills/triage-new-issues
+++ b/.agents/skills/triage-new-issues
@@ -1,0 +1,1 @@
+../../skills/triage-new-issues

--- a/.agents/skills/working-on-an-issue
+++ b/.agents/skills/working-on-an-issue
@@ -1,0 +1,1 @@
+../../skills/working-on-an-issue

--- a/.agents/skills/writing-product-specs
+++ b/.agents/skills/writing-product-specs
@@ -1,0 +1,1 @@
+../../skills/writing-product-specs

--- a/.agents/skills/writing-user-stories
+++ b/.agents/skills/writing-user-stories
@@ -1,0 +1,1 @@
+../../skills/writing-user-stories

--- a/.agents/skills/writing-verification-plans
+++ b/.agents/skills/writing-verification-plans
@@ -1,0 +1,1 @@
+../../skills/writing-verification-plans

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "claude-code-skills",
+  "description": "Skills for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more",
+  "version": "3.1.0",
+  "author": {
+    "name": "Britt Crawford",
+    "email": "britt@brittcrawford.com"
+  },
+  "homepage": "https://github.com/britt/claude-code-skills",
+  "repository": "https://github.com/britt/claude-code-skills",
+  "license": "MIT",
+  "keywords": ["skills", "tdd", "project-setup", "product-specs", "user-stories", "verification", "planning"],
+  "skills": "./skills/"
+}

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "britt",
+  "owner": {
+    "name": "Britt Crawford",
+    "email": "britt@brittcrawford.com"
+  },
+  "metadata": {
+    "description": "A collection of skills for Claude Code to enhance AI-assisted development workflows"
+  },
+  "plugins": [
+    {
+      "name": "claude-code-skills",
+      "source": "./",
+      "description": "All skills bundled together for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more"
+    },
+    {
+      "name": "project-foundations",
+      "source": "./bundles/project-foundations",
+      "description": "A curated bundle for taking a new project from concept to a diagrammed, story-driven plan: project setup, issue decomposition, user stories, verification plans, and architecture/dependency/Mermaid diagrams"
+    }
+  ]
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "claude-code-skills",
+  "displayName": "Claude Code Skills",
+  "description": "Skills for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more",
+  "version": "3.1.0",
+  "author": {
+    "name": "Britt Crawford",
+    "email": "britt@brittcrawford.com"
+  },
+  "homepage": "https://github.com/britt/claude-code-skills",
+  "repository": "https://github.com/britt/claude-code-skills",
+  "license": "MIT",
+  "keywords": ["skills", "tdd", "project-setup", "product-specs", "user-stories", "verification", "planning"],
+  "category": "productivity",
+  "tags": ["skills", "tdd", "planning", "specs", "development"],
+  "skills": "./skills/"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,19 @@ Guidelines for contributing to this skills repository.
 claude-code-skills/
 ├── README.md                 # Installation and usage guide
 ├── CONTRIBUTING.md           # This file
+├── sync-agents-skills.sh     # Keeps .agents/skills/ symlinks in sync with skills/
 ├── .claude-plugin/
-│   └── marketplace.json      # Plugin marketplace configuration
+│   ├── marketplace.json      # Claude Code plugin marketplace configuration
+│   └── plugin.json           # Claude Code plugin manifest (full bundle)
+├── .codex-plugin/
+│   └── plugin.json           # Codex CLI plugin manifest (full bundle; reuses .claude-plugin/marketplace.json)
+├── .cursor-plugin/
+│   ├── marketplace.json      # Cursor plugin marketplace configuration
+│   └── plugin.json           # Cursor plugin manifest (full bundle)
+├── .agents/
+│   └── skills/                       # Symlinks only — read by Codex CLI, OpenCode, Cursor
+│       ├── daily-planning-ritual -> ../../skills/daily-planning-ritual
+│       └── ...
 ├── docs/
 │   └── plans/                # Design documents for skills
 │       └── 2025-11-09-summoning-user-design.md
@@ -24,6 +35,8 @@ claude-code-skills/
     └── writing-user-stories/
         └── SKILL.md
 ```
+
+`skills/` is the single canonical copy of every skill. `.agents/skills/` holds only symlinks back into it (read natively by Codex CLI, OpenCode, and Cursor) — never commit real files there.
 
 ## Creating a New Skill
 
@@ -75,7 +88,11 @@ Optional elements:
 - Anti-patterns
 - Examples
 
-### 3. Update Marketplace (Required)
+### 3. Link into .agents/skills/ (Required)
+
+Run `./sync-agents-skills.sh` to add the `.agents/skills/<name>` symlink for your new skill (and clean up any stale ones). This is what makes the skill discoverable by Codex CLI, OpenCode, and Cursor — commit the symlink, not a copy of the file.
+
+### 4. Update Marketplace (Required)
 
 Add the new skill to `.claude-plugin/marketplace.json`:
 
@@ -95,6 +112,12 @@ Add the new skill to `.claude-plugin/marketplace.json`:
   "tags": ["tag1", "tag2"]
 }
 ```
+
+New skills are picked up automatically by the Codex/Cursor full-bundle plugins (they reference the whole `skills/` directory) — no per-skill entry needed there. Granular per-skill installs are currently a Claude Code-only feature.
+
+### 5. Bumping the Bundle Version (Required when releasing)
+
+The full-bundle skill archive is described in four places that must stay in lockstep: `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`, and the `claude-code-skills` entry in `.claude-plugin/marketplace.json`. The `project-foundations` bundle has the same set under `bundles/project-foundations/`.
 
 ## Building Skill Archives
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,40 @@ git clone https://github.com/britt/claude-code-skills.git .claude/skills/claude-
 
 Restart Claude Code after installation to load new skills.
 
+### Codex CLI
+
+This repo is a Codex plugin marketplace (`.codex-plugin/plugin.json` + the existing `.claude-plugin/marketplace.json`, which Codex also reads):
+
+```bash
+codex plugin marketplace add britt/claude-code-skills
+codex plugin install claude-code-skills@britt        # all skills
+codex plugin install project-foundations@britt       # curated bundle only
+```
+
+### Cursor
+
+This repo ships a native Cursor plugin manifest (`.cursor-plugin/plugin.json`) and marketplace catalog (`.cursor-plugin/marketplace.json`). Cursor's marketplace-add flow is dashboard-based (no CLI yet): **Dashboard → Plugins → Team Marketplaces → Add Marketplace → Import from Repo**, pointing at `britt/claude-code-skills`, then install `claude-code-skills` (or `project-foundations`) from **Customize** in the sidebar.
+
+### Codex CLI, OpenCode, and Cursor: Manual Installation
+
+All three also discover skills the same way Claude Code does — a `SKILL.md` with `name`/`description` frontmatter, auto-triggered by relevance — under the shared `.agents/skills/` path. This repo already exposes every skill there (`.agents/skills/<name>` symlinked to `skills/<name>`, so there's only ever one copy of each skill's content). This is the option to use for OpenCode, which has no marketplace, or if you'd rather not use Codex's/Cursor's plugin flow above.
+
+**Global installation** (available in all projects):
+
+```bash
+git clone https://github.com/britt/claude-code-skills.git ~/.agents-skills-src
+mkdir -p ~/.agents/skills
+for dir in ~/.agents-skills-src/skills/*/; do
+  ln -s "$dir" ~/.agents/skills/"$(basename "$dir")"
+done
+```
+
+**Project-specific installation**: clone into the project and symlink, or run `./sync-agents-skills.sh` after copying `skills/` into your project's own `.agents/skills/`.
+
+Codex CLI also reads `~/.codex/AGENTS.md` / project `AGENTS.md`, OpenCode reads `AGENTS.md` and natively falls back to `.claude/skills/`, and Cursor also reads `.cursor/skills/` — so a plain `git clone` into any of those tool-specific directories works too. Restart the tool after installation to load new skills.
+
+**Note:** Some skills (like `sgai-goal` and `setting-up-a-project`) reference Claude Code-specific tooling (e.g. `CLAUDE.md`, `TodoWrite`) and may need minor adaptation to work identically in other tools; most skills are plain instructional markdown and are unaffected. Granular per-skill plugin installs (like `/plugin install architecture-diagramming@britt` for Claude Code) aren't set up for Codex/Cursor yet — only the two bundles above; use the manual `.agents/skills/` installation for individual-skill granularity on those tools.
+
 ### Claude.ai (Web and iOS)
 
 Skills can be added to Claude.ai projects as project knowledge:

--- a/bundles/project-foundations/.codex-plugin/plugin.json
+++ b/bundles/project-foundations/.codex-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "project-foundations",
+  "description": "A curated bundle for taking a new project from concept to a diagrammed, story-driven plan: project setup, issue decomposition, user stories, verification plans, and architecture/dependency/Mermaid diagrams",
+  "version": "2.0.0",
+  "author": {
+    "name": "Britt Crawford",
+    "email": "britt@brittcrawford.com"
+  },
+  "homepage": "https://github.com/britt/claude-code-skills",
+  "repository": "https://github.com/britt/claude-code-skills",
+  "license": "MIT",
+  "keywords": ["bundle", "planning", "setup", "user-stories", "diagrams", "verification", "issues"],
+  "skills": "./skills/"
+}

--- a/bundles/project-foundations/.cursor-plugin/plugin.json
+++ b/bundles/project-foundations/.cursor-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "project-foundations",
+  "displayName": "Project Foundations",
+  "description": "A curated bundle for taking a new project from concept to a diagrammed, story-driven plan: project setup, issue decomposition, user stories, verification plans, and architecture/dependency/Mermaid diagrams",
+  "version": "2.0.0",
+  "author": {
+    "name": "Britt Crawford",
+    "email": "britt@brittcrawford.com"
+  },
+  "homepage": "https://github.com/britt/claude-code-skills",
+  "repository": "https://github.com/britt/claude-code-skills",
+  "license": "MIT",
+  "keywords": ["bundle", "planning", "setup", "user-stories", "diagrams", "verification", "issues"],
+  "category": "productivity",
+  "tags": ["bundle", "planning", "setup", "user-stories", "diagrams", "verification", "issues"],
+  "skills": "./skills/"
+}

--- a/sync-agents-skills.sh
+++ b/sync-agents-skills.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Keep .agents/skills/ in sync with skills/ so Codex CLI, OpenCode, and
+# Cursor (which all discover skills under .agents/skills/) see the same
+# canonical skill content as Claude Code, with no duplicated files.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+mkdir -p .agents/skills
+
+# Add a symlink for any skill missing one.
+for dir in skills/*/; do
+  name=$(basename "$dir")
+  link=".agents/skills/$name"
+  if [ ! -e "$link" ]; then
+    ln -s "../../skills/$name" "$link"
+    echo "Linked $link -> skills/$name"
+  fi
+done
+
+# Remove symlinks for skills that no longer exist.
+for link in .agents/skills/*/; do
+  name=$(basename "$link")
+  if [ ! -d "skills/$name" ]; then
+    rm "$link" 2>/dev/null || rm -rf "${link%/}"
+    echo "Removed stale link .agents/skills/$name"
+  fi
+done
+
+echo "Done! .agents/skills/ is in sync with skills/."


### PR DESCRIPTION
Adds cross-tool support by symlinking every skill under `.agents/skills/`, the shared path Codex CLI, OpenCode, and Cursor all read natively — no duplicated content, `skills/` stays the single source of truth. Adds Codex (`.codex-plugin/plugin.json`) and Cursor (`.cursor-plugin/plugin.json` + `marketplace.json`) plugin manifests for the full skill bundle and the `project-foundations` bundle, so both tools can install via their native plugin marketplace flow. Adds `sync-agents-skills.sh` to keep the symlinks in sync when skills are added or removed. Updates README and CONTRIBUTING with install instructions and a maintenance checklist for each tool. Granular per-skill installs (as opposed to the two bundles) are intentionally out of scope for Codex/Cursor for now — see CONTRIBUTING.md for why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)