### PR TITLE
fix(ci): bump GitHub Actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -41,13 +41,13 @@ jobs:
       - name: Install Dart Sass
         run: sudo snap install dart-sass
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           fetch-depth: 0
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo
@@ -62,7 +62,7 @@ jobs:
             --baseURL "${{ steps.pages.outputs.base_url }}/"
         working-directory: site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./site/public
 
@@ -76,4 +76,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- `actions/checkout`, `configure-pages`, `upload-pages-artifact`, and `deploy-pages` in `.github/workflows/hugo.yml` were pinned to majors still on the deprecated Node 20 runtime.
- Bumped each to its latest major (`v7`, `v6`, `v5`, `v5` respectively), all verified on Node 24.

## Test plan
- [x] Verified each action's `action.yml` on GitHub confirms `using: node24` (or wraps an action that does) at the new pinned version.
- [ ] Confirm the `Deploy Hugo site to Pages` workflow runs green after merge.