### PR TITLE
Add vouch GitHub Action to gate PRs

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -1,0 +1,10 @@
+# Vouched contributors for this project.
+#
+# See https://github.com/mitchellh/vouch for details.
+#
+# Syntax:
+#   - One handle per line (without @), sorted alphabetically.
+#   - Optional platform prefix: platform:username (e.g., github:user).
+#   - Denounce with minus prefix: -username or -platform:username.
+#   - Optional details after a space following the handle.
+britt

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -1,0 +1,31 @@
+# Blocks PRs from unvouched or denounced authors. Bots and collaborators
+# with write access are always allowed through automatically.
+#
+# The vouched/denounced list lives in .github/VOUCHED.td. Maintainers can
+# add contributors with `vouch <username> --write` (see
+# https://github.com/mitchellh/vouch) or by editing the file directly.
+#
+# auto-close is off by default so this only reports status until the
+# VOUCHED.td list has been populated with real contributors. Flip it to
+# true once you're ready to have unvouched PRs closed automatically.
+
+name: Vouch check PR
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mitchellh/vouch/action/check-pr@v1
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          auto-close: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds mitchellh/vouch's `check-pr` action, gating PRs from unvouched/denounced contributors while auto-allowing bots and collaborators with write access.
- Seeds `.github/VOUCHED.td` with `britt` as the initial vouched contributor.
- `auto-close` is left off for now so the workflow only reports status until the vouch list is populated with real contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)