### PR TITLE
Rename bundle plugin from claude-code-skills to agent-skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   },
   "plugins": [
     {
-      "name": "claude-code-skills",
+      "name": "agent-skills",
       "description": "All skills bundled together for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more",
       "version": "3.2.0",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
-  "name": "claude-code-skills",
+  "name": "agent-skills",
   "description": "Skills for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more",
   "version": "3.2.0",
   "author": {
     "name": "Britt Crawford",
     "email": "britt@brittcrawford.com"
   },
-  "homepage": "https://github.com/britt/claude-code-skills",
-  "repository": "https://github.com/britt/claude-code-skills",
+  "homepage": "https://github.com/britt/agent-skills",
+  "repository": "https://github.com/britt/agent-skills",
   "license": "MIT",
   "keywords": ["skills", "tdd", "project-setup", "product-specs", "user-stories", "verification", "planning"]
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
-  "name": "claude-code-skills",
+  "name": "agent-skills",
   "description": "Skills for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more",
   "version": "3.2.0",
   "author": {
     "name": "Britt Crawford",
     "email": "britt@brittcrawford.com"
   },
-  "homepage": "https://github.com/britt/claude-code-skills",
-  "repository": "https://github.com/britt/claude-code-skills",
+  "homepage": "https://github.com/britt/agent-skills",
+  "repository": "https://github.com/britt/agent-skills",
   "license": "MIT",
   "keywords": ["skills", "tdd", "project-setup", "product-specs", "user-stories", "verification", "planning"],
   "skills": "./skills/"

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
   },
   "plugins": [
     {
-      "name": "claude-code-skills",
+      "name": "agent-skills",
       "source": "./",
       "description": "All skills bundled together for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more"
     },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,14 +1,14 @@
 {
-  "name": "claude-code-skills",
-  "displayName": "Claude Code Skills",
+  "name": "agent-skills",
+  "displayName": "Agent Skills",
   "description": "Skills for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more",
   "version": "3.2.0",
   "author": {
     "name": "Britt Crawford",
     "email": "britt@brittcrawford.com"
   },
-  "homepage": "https://github.com/britt/claude-code-skills",
-  "repository": "https://github.com/britt/claude-code-skills",
+  "homepage": "https://github.com/britt/agent-skills",
+  "repository": "https://github.com/britt/agent-skills",
   "license": "MIT",
   "keywords": ["skills", "tdd", "project-setup", "product-specs", "user-stories", "verification", "planning"],
   "category": "productivity",

--- a/bundles/project-foundations/.claude-plugin/plugin.json
+++ b/bundles/project-foundations/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Britt Crawford",
     "email": "britt@brittcrawford.com"
   },
-  "homepage": "https://github.com/britt/claude-code-skills",
-  "repository": "https://github.com/britt/claude-code-skills",
+  "homepage": "https://github.com/britt/agent-skills",
+  "repository": "https://github.com/britt/agent-skills",
   "license": "MIT",
   "keywords": ["bundle", "planning", "setup", "user-stories", "diagrams", "verification", "issues"]
 }

--- a/bundles/project-foundations/.codex-plugin/plugin.json
+++ b/bundles/project-foundations/.codex-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Britt Crawford",
     "email": "britt@brittcrawford.com"
   },
-  "homepage": "https://github.com/britt/claude-code-skills",
-  "repository": "https://github.com/britt/claude-code-skills",
+  "homepage": "https://github.com/britt/agent-skills",
+  "repository": "https://github.com/britt/agent-skills",
   "license": "MIT",
   "keywords": ["bundle", "planning", "setup", "user-stories", "diagrams", "verification", "issues"],
   "skills": "./skills/"

--- a/bundles/project-foundations/.cursor-plugin/plugin.json
+++ b/bundles/project-foundations/.cursor-plugin/plugin.json
@@ -7,8 +7,8 @@
     "name": "Britt Crawford",
     "email": "britt@brittcrawford.com"
   },
-  "homepage": "https://github.com/britt/claude-code-skills",
-  "repository": "https://github.com/britt/claude-code-skills",
+  "homepage": "https://github.com/britt/agent-skills",
+  "repository": "https://github.com/britt/agent-skills",
   "license": "MIT",
   "keywords": ["bundle", "planning", "setup", "user-stories", "diagrams", "verification", "issues"],
   "category": "productivity",


### PR DESCRIPTION
## Summary
- Renamed the top-level "install everything" bundle plugin from `claude-code-skills` to `agent-skills` to match the GitHub repo's move to `github.com/britt/agent-skills`
- Updated `homepage`/`repository` URLs across all plugin/marketplace manifests (`.claude-plugin`, `.cursor-plugin`, `.codex-plugin`, including the `project-foundations` bundle)
- Individual skill plugin names (e.g. `architecture-diagramming`) are unchanged; only the bundle-all plugin identifier and repo URLs moved

## Test plan
- [x] Validated all edited `plugin.json`/`marketplace.json` files parse as valid JSON
- [x] Confirmed no remaining `claude-code-skills` references in manifest files