### PR TITLE
chore(release): bump version to 4.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "britt",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "A collection of skills for Claude Code to enhance AI-assisted development workflows",
   "owner": {
     "name": "Britt Crawford",
@@ -11,7 +11,7 @@
     {
       "name": "agent-skills",
       "description": "All skills bundled together for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more",
-      "version": "3.2.0",
+      "version": "4.0.0",
       "author": {
         "name": "Britt Crawford",
         "email": "britt@brittcrawford.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-skills",
   "description": "Skills for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "author": {
     "name": "Britt Crawford",
     "email": "britt@brittcrawford.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-skills",
   "description": "Skills for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "author": {
     "name": "Britt Crawford",
     "email": "britt@brittcrawford.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "agent-skills",
   "displayName": "Agent Skills",
   "description": "Skills for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "author": {
     "name": "Britt Crawford",
     "email": "britt@brittcrawford.com"


### PR DESCRIPTION
## Summary
- Bumps the marketplace and bundle plugin version from 3.2.0 to 4.0.0 (major bump), following the pattern of the prior release commit
- Signals the breaking rename of the bundle plugin from `claude-code-skills` to `agent-skills` merged in #61 — the marketplace install name changed, so existing `/plugin install claude-code-skills@britt` users need to reinstall
- Touches `.claude-plugin/marketplace.json`, `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`; individual skill plugin versions and `project-foundations` are untouched

## Test plan
- [x] Validated all edited `plugin.json`/`marketplace.json` files parse as valid JSON