### PR TITLE
Fix broken skill links and stale repo references in docs site

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -71,31 +71,31 @@ See the [Contributing Guide](https://github.com/britt/agent-skills/blob/main/CON
 
 | Skill | Description |
 | --- | --- |
-| [Architecture Diagramming](/skills/architecture-diagramming/) | Generate Mermaid architecture diagrams showing system components, layers, and data flows |
-| [At-Risk Detection](/skills/at-risk-detection/) | Proactively identify at-risk issues and PRs: stale items, blocked work, deadline risks, scope creep, and unassigned high-priority items |
-| [Build FAQ from Issues](/skills/build-faq-from-issues/) | Extract common questions from closed GitHub issues and generate an FAQ document with answers |
-| [Consolidate Notes Summary](/skills/consolidate-notes-summary/) | Search project notes by topic, synthesize findings into a consolidated summary with cross-references |
-| [Context-Aware Questions](/skills/context-aware-questions/) | Identify information gaps in project context and generate actionable questions to surface missing requirements |
-| [Daily Planning Ritual](/skills/daily-planning-ritual/) | Interactive daily planning across work and personal life dimensions |
-| [Dependency Mapping](/skills/dependency-mapping/) | Generate Mermaid dependency graphs showing issue relationships, blocking chains, and critical paths |
-| [Idea to Design](/skills/idea-to-design/) | Transform raw idea notes into comprehensive design documents with research and decisions |
-| [Issue Decomposition](/skills/issue-decomposition/) | Decompose project descriptions into well-structured GitHub issues with user stories, acceptance criteria, and estimates |
-| [Markdown Formatting](/skills/markdown-formatting/) | Format AI outputs into consistent, readable Markdown for PRs, issues, docs, and notes |
-| [Mermaid Diagrams](/skills/mermaid-diagrams/) | Guide for creating syntactically correct Mermaid diagrams that render properly on GitHub |
-| [Prepare Meeting Agenda](/skills/prepare-meeting-agenda/) | Generate meeting agendas from recent issues, PRs, and notes for sprint planning, retros, and standups |
-| [Project Analysis](/skills/project-analysis/) | Analyze project codebase structure, architecture, key files, and dependencies |
-| [Project Foundations (Bundle)](/skills/project-foundations/) | A curated bundle for taking a new project from concept to a diagrammed, story-driven plan with supported coding agents |
-| [Project Planning](/skills/project-planning/) | Orchestrate comprehensive project planning with issues, architecture diagrams, dependency maps, and timelines |
-| [Requirement Elicitation](/skills/requirement-elicitation/) | Adaptive conversational wizard for eliciting project requirements across functional, nonfunctional, and edge-case dimensions |
-| [Research Topic and Summarize](/skills/research-topic-summarize/) | Research topics via web search, synthesize detailed summaries with sources and screenshots |
-| [Setting Up a Project](/skills/setting-up-a-project/) | Author CLAUDE.md with project purpose, tech stack, and development practices |
-| [SGAI Goal Authoring](/skills/sgai-goal/) | Compose GOAL.md files for SGAI workspaces through interactive conversation |
-| [Stakeholder Tracking](/skills/stakeholder-tracking/) | Define stakeholder personas and track their goals to ensure all perspectives are addressed |
-| [Stakeholder Updates](/skills/stakeholder-updates/) | Craft clear, concise stakeholder communications with appropriate context and framing |
-| [Summarize Conversation Thread](/skills/summarize-conversation-thread/) | Summarize GitHub issue and PR threads into key decisions, action items, and next steps |
-| [Timeline Planning](/skills/timeline-planning/) | Generate Mermaid Gantt charts for project timelines with phases, dependencies, and milestones |
-| [Triage New Issues](/skills/triage-new-issues/) | Review new GitHub issues, assess priority and urgency, suggest labels, and recommend assignees |
-| [Working on an Issue](/skills/working-on-an-issue/) | Hands-off implementation of GitHub issues, reviewed at the PR |
-| [Writing Product Specs](/skills/writing-product-specs/) | Write comprehensive product specification documents |
-| [Writing User Stories](/skills/writing-user-stories/) | Write properly formatted user stories for task definition |
-| [Writing Verification Plans](/skills/writing-verification-plans/) | Create real-world acceptance testing procedures |
+| [Architecture Diagramming]({{< relref "skills/architecture-diagramming.md" >}}) | Generate Mermaid architecture diagrams showing system components, layers, and data flows |
+| [At-Risk Detection]({{< relref "skills/at-risk-detection.md" >}}) | Proactively identify at-risk issues and PRs: stale items, blocked work, deadline risks, scope creep, and unassigned high-priority items |
+| [Build FAQ from Issues]({{< relref "skills/build-faq-from-issues.md" >}}) | Extract common questions from closed GitHub issues and generate an FAQ document with answers |
+| [Consolidate Notes Summary]({{< relref "skills/consolidate-notes-summary.md" >}}) | Search project notes by topic, synthesize findings into a consolidated summary with cross-references |
+| [Context-Aware Questions]({{< relref "skills/context-aware-questions.md" >}}) | Identify information gaps in project context and generate actionable questions to surface missing requirements |
+| [Daily Planning Ritual]({{< relref "skills/daily-planning-ritual.md" >}}) | Interactive daily planning across work and personal life dimensions |
+| [Dependency Mapping]({{< relref "skills/dependency-mapping.md" >}}) | Generate Mermaid dependency graphs showing issue relationships, blocking chains, and critical paths |
+| [Idea to Design]({{< relref "skills/idea-to-design.md" >}}) | Transform raw idea notes into comprehensive design documents with research and decisions |
+| [Issue Decomposition]({{< relref "skills/issue-decomposition.md" >}}) | Decompose project descriptions into well-structured GitHub issues with user stories, acceptance criteria, and estimates |
+| [Markdown Formatting]({{< relref "skills/markdown-formatting.md" >}}) | Format AI outputs into consistent, readable Markdown for PRs, issues, docs, and notes |
+| [Mermaid Diagrams]({{< relref "skills/mermaid-diagrams.md" >}}) | Guide for creating syntactically correct Mermaid diagrams that render properly on GitHub |
+| [Prepare Meeting Agenda]({{< relref "skills/prepare-meeting-agenda.md" >}}) | Generate meeting agendas from recent issues, PRs, and notes for sprint planning, retros, and standups |
+| [Project Analysis]({{< relref "skills/project-analysis.md" >}}) | Analyze project codebase structure, architecture, key files, and dependencies |
+| [Project Foundations (Bundle)]({{< relref "skills/project-foundations.md" >}}) | A curated bundle for taking a new project from concept to a diagrammed, story-driven plan with supported coding agents |
+| [Project Planning]({{< relref "skills/project-planning.md" >}}) | Orchestrate comprehensive project planning with issues, architecture diagrams, dependency maps, and timelines |
+| [Requirement Elicitation]({{< relref "skills/requirement-elicitation.md" >}}) | Adaptive conversational wizard for eliciting project requirements across functional, nonfunctional, and edge-case dimensions |
+| [Research Topic and Summarize]({{< relref "skills/research-topic-summarize.md" >}}) | Research topics via web search, synthesize detailed summaries with sources and screenshots |
+| [Setting Up a Project]({{< relref "skills/setting-up-a-project.md" >}}) | Author CLAUDE.md with project purpose, tech stack, and development practices |
+| [SGAI Goal Authoring]({{< relref "skills/sgai-goal.md" >}}) | Compose GOAL.md files for SGAI workspaces through interactive conversation |
+| [Stakeholder Tracking]({{< relref "skills/stakeholder-tracking.md" >}}) | Define stakeholder personas and track their goals to ensure all perspectives are addressed |
+| [Stakeholder Updates]({{< relref "skills/stakeholder-updates.md" >}}) | Craft clear, concise stakeholder communications with appropriate context and framing |
+| [Summarize Conversation Thread]({{< relref "skills/summarize-conversation-thread.md" >}}) | Summarize GitHub issue and PR threads into key decisions, action items, and next steps |
+| [Timeline Planning]({{< relref "skills/timeline-planning.md" >}}) | Generate Mermaid Gantt charts for project timelines with phases, dependencies, and milestones |
+| [Triage New Issues]({{< relref "skills/triage-new-issues.md" >}}) | Review new GitHub issues, assess priority and urgency, suggest labels, and recommend assignees |
+| [Working on an Issue]({{< relref "skills/working-on-an-issue.md" >}}) | Hands-off implementation of GitHub issues, reviewed at the PR |
+| [Writing Product Specs]({{< relref "skills/writing-product-specs.md" >}}) | Write comprehensive product specification documents |
+| [Writing User Stories]({{< relref "skills/writing-user-stories.md" >}}) | Write properly formatted user stories for task definition |
+| [Writing Verification Plans]({{< relref "skills/writing-verification-plans.md" >}}) | Create real-world acceptance testing procedures |

--- a/site/content/skill-list.md
+++ b/site/content/skill-list.md
@@ -9,46 +9,46 @@ This page maps every skill page in the site, and each entry below includes a sho
 
 ### Development Workflow
 
-- [SGAI Goal Authoring](/skills/sgai-goal/) — Compose GOAL.md files for SGAI workspaces through interactive conversation.
-- [Setting Up a Project](/skills/setting-up-a-project/) — Author CLAUDE.md with project purpose, tech stack, and development practices.
-- [Working on an Issue](/skills/working-on-an-issue/) — Hands-off implementation of GitHub issues, reviewed at the PR.
-- [Project Analysis](/skills/project-analysis/) — Analyze project codebase structure, architecture, key files, and dependencies.
-- [Project Planning](/skills/project-planning/) — Orchestrate comprehensive project planning with issues, architecture diagrams, dependency maps, and timelines.
-- [Issue Decomposition](/skills/issue-decomposition/) — Decompose project descriptions into well-structured GitHub issues with user stories, acceptance criteria, and estimates.
-- [Dependency Mapping](/skills/dependency-mapping/) — Generate Mermaid dependency graphs showing issue relationships, blocking chains, and critical paths.
-- [Timeline Planning](/skills/timeline-planning/) — Generate Mermaid Gantt charts for project timelines with phases, dependencies, and milestones.
+- [SGAI Goal Authoring]({{< relref "skills/sgai-goal.md" >}}) — Compose GOAL.md files for SGAI workspaces through interactive conversation.
+- [Setting Up a Project]({{< relref "skills/setting-up-a-project.md" >}}) — Author CLAUDE.md with project purpose, tech stack, and development practices.
+- [Working on an Issue]({{< relref "skills/working-on-an-issue.md" >}}) — Hands-off implementation of GitHub issues, reviewed at the PR.
+- [Project Analysis]({{< relref "skills/project-analysis.md" >}}) — Analyze project codebase structure, architecture, key files, and dependencies.
+- [Project Planning]({{< relref "skills/project-planning.md" >}}) — Orchestrate comprehensive project planning with issues, architecture diagrams, dependency maps, and timelines.
+- [Issue Decomposition]({{< relref "skills/issue-decomposition.md" >}}) — Decompose project descriptions into well-structured GitHub issues with user stories, acceptance criteria, and estimates.
+- [Dependency Mapping]({{< relref "skills/dependency-mapping.md" >}}) — Generate Mermaid dependency graphs showing issue relationships, blocking chains, and critical paths.
+- [Timeline Planning]({{< relref "skills/timeline-planning.md" >}}) — Generate Mermaid Gantt charts for project timelines with phases, dependencies, and milestones.
 
 ### Requirements & Planning
 
-- [Requirement Elicitation](/skills/requirement-elicitation/) — Adaptive conversational wizard for eliciting project requirements across functional, nonfunctional, and edge-case dimensions.
-- [Idea to Design](/skills/idea-to-design/) — Transform raw idea notes into comprehensive design documents with research and decisions.
-- [Writing Product Specs](/skills/writing-product-specs/) — Write comprehensive product specification documents.
-- [Writing User Stories](/skills/writing-user-stories/) — Write properly formatted user stories for task definition.
-- [Writing Verification Plans](/skills/writing-verification-plans/) — Create real-world acceptance testing procedures.
-- [Context-Aware Questions](/skills/context-aware-questions/) — Identify information gaps in project context and generate actionable questions to surface missing requirements.
+- [Requirement Elicitation]({{< relref "skills/requirement-elicitation.md" >}}) — Adaptive conversational wizard for eliciting project requirements across functional, nonfunctional, and edge-case dimensions.
+- [Idea to Design]({{< relref "skills/idea-to-design.md" >}}) — Transform raw idea notes into comprehensive design documents with research and decisions.
+- [Writing Product Specs]({{< relref "skills/writing-product-specs.md" >}}) — Write comprehensive product specification documents.
+- [Writing User Stories]({{< relref "skills/writing-user-stories.md" >}}) — Write properly formatted user stories for task definition.
+- [Writing Verification Plans]({{< relref "skills/writing-verification-plans.md" >}}) — Create real-world acceptance testing procedures.
+- [Context-Aware Questions]({{< relref "skills/context-aware-questions.md" >}}) — Identify information gaps in project context and generate actionable questions to surface missing requirements.
 
 ### Project Management
 
-- [At-Risk Detection](/skills/at-risk-detection/) — Proactively identify at-risk issues and PRs: stale items, blocked work, deadline risks, scope creep, and unassigned high-priority items.
-- [Triage New Issues](/skills/triage-new-issues/) — Review new GitHub issues, assess priority and urgency, suggest labels, and recommend assignees.
-- [Stakeholder Tracking](/skills/stakeholder-tracking/) — Define stakeholder personas and track their goals to ensure all perspectives are addressed.
-- [Stakeholder Updates](/skills/stakeholder-updates/) — Craft clear, concise stakeholder communications with appropriate context and framing.
-- [Prepare Meeting Agenda](/skills/prepare-meeting-agenda/) — Generate meeting agendas from recent issues, PRs, and notes for sprint planning, retros, and standups.
+- [At-Risk Detection]({{< relref "skills/at-risk-detection.md" >}}) — Proactively identify at-risk issues and PRs: stale items, blocked work, deadline risks, scope creep, and unassigned high-priority items.
+- [Triage New Issues]({{< relref "skills/triage-new-issues.md" >}}) — Review new GitHub issues, assess priority and urgency, suggest labels, and recommend assignees.
+- [Stakeholder Tracking]({{< relref "skills/stakeholder-tracking.md" >}}) — Define stakeholder personas and track their goals to ensure all perspectives are addressed.
+- [Stakeholder Updates]({{< relref "skills/stakeholder-updates.md" >}}) — Craft clear, concise stakeholder communications with appropriate context and framing.
+- [Prepare Meeting Agenda]({{< relref "skills/prepare-meeting-agenda.md" >}}) — Generate meeting agendas from recent issues, PRs, and notes for sprint planning, retros, and standups.
 
 ### Documentation & Communication
 
-- [Architecture Diagramming](/skills/architecture-diagramming/) — Generate Mermaid architecture diagrams showing system components, layers, and data flows.
-- [Mermaid Diagrams](/skills/mermaid-diagrams/) — Guide for creating syntactically correct Mermaid diagrams that render properly on GitHub.
-- [Markdown Formatting](/skills/markdown-formatting/) — Format AI outputs into consistent, readable Markdown for PRs, issues, docs, and notes.
-- [Build FAQ from Issues](/skills/build-faq-from-issues/) — Extract common questions from closed GitHub issues and generate an FAQ document with answers.
-- [Summarize Conversation Thread](/skills/summarize-conversation-thread/) — Summarize GitHub issue and PR threads into key decisions, action items, and next steps.
-- [Consolidate Notes Summary](/skills/consolidate-notes-summary/) — Search project notes by topic, synthesize findings into a consolidated summary with cross-references.
-- [Research Topic and Summarize](/skills/research-topic-summarize/) — Research topics via web search, synthesize detailed summaries with sources and screenshots.
+- [Architecture Diagramming]({{< relref "skills/architecture-diagramming.md" >}}) — Generate Mermaid architecture diagrams showing system components, layers, and data flows.
+- [Mermaid Diagrams]({{< relref "skills/mermaid-diagrams.md" >}}) — Guide for creating syntactically correct Mermaid diagrams that render properly on GitHub.
+- [Markdown Formatting]({{< relref "skills/markdown-formatting.md" >}}) — Format AI outputs into consistent, readable Markdown for PRs, issues, docs, and notes.
+- [Build FAQ from Issues]({{< relref "skills/build-faq-from-issues.md" >}}) — Extract common questions from closed GitHub issues and generate an FAQ document with answers.
+- [Summarize Conversation Thread]({{< relref "skills/summarize-conversation-thread.md" >}}) — Summarize GitHub issue and PR threads into key decisions, action items, and next steps.
+- [Consolidate Notes Summary]({{< relref "skills/consolidate-notes-summary.md" >}}) — Search project notes by topic, synthesize findings into a consolidated summary with cross-references.
+- [Research Topic and Summarize]({{< relref "skills/research-topic-summarize.md" >}}) — Research topics via web search, synthesize detailed summaries with sources and screenshots.
 
 ### Personal & Utilities
 
-- [Daily Planning Ritual](/skills/daily-planning-ritual/) — Interactive daily planning across work and personal life dimensions.
+- [Daily Planning Ritual]({{< relref "skills/daily-planning-ritual.md" >}}) — Interactive daily planning across work and personal life dimensions.
 
 ### Bundle
 
-- [Project Foundations (Bundle)](/skills/project-foundations/) — A curated bundle for taking a new project from concept to a diagrammed, story-driven plan.
+- [Project Foundations (Bundle)]({{< relref "skills/project-foundations.md" >}}) — A curated bundle for taking a new project from concept to a diagrammed, story-driven plan.

--- a/site/content/skills/project-foundations.md
+++ b/site/content/skills/project-foundations.md
@@ -18,13 +18,13 @@ A curated bundle for taking a new project from concept to a diagrammed, story-dr
 
 | Skill | Description |
 |-------|-------------|
-| [Setting Up a Project](./setting-up-a-project/) | Authors a CLAUDE.md file that defines your project's purpose, tech stack, and development practices before any code is written. |
-| [Issue Decomposition](./issue-decomposition/) | Decompose projects into well-structured GitHub issues with user stories, acceptance criteria, and estimates. |
-| [Writing User Stories](./writing-user-stories/) | Write properly formatted user stories with Given-When-Then acceptance criteria and an INVEST quality checklist. |
-| [Writing Verification Plans](./writing-verification-plans/) | Create verification plans for real-world acceptance testing with concrete scenarios and success criteria. |
-| [Architecture Diagramming](./architecture-diagramming/) | Generate Mermaid architecture diagrams showing system components, layers, and data flows. |
-| [Dependency Mapping](./dependency-mapping/) | Generate Mermaid dependency graphs showing issue relationships, blocking chains, and critical paths. |
-| [Mermaid Diagrams](./mermaid-diagrams/) | Guide for creating syntactically correct Mermaid diagrams that render properly on GitHub. |
+| [Setting Up a Project]({{< relref "skills/setting-up-a-project.md" >}}) | Authors a CLAUDE.md file that defines your project's purpose, tech stack, and development practices before any code is written. |
+| [Issue Decomposition]({{< relref "skills/issue-decomposition.md" >}}) | Decompose projects into well-structured GitHub issues with user stories, acceptance criteria, and estimates. |
+| [Writing User Stories]({{< relref "skills/writing-user-stories.md" >}}) | Write properly formatted user stories with Given-When-Then acceptance criteria and an INVEST quality checklist. |
+| [Writing Verification Plans]({{< relref "skills/writing-verification-plans.md" >}}) | Create verification plans for real-world acceptance testing with concrete scenarios and success criteria. |
+| [Architecture Diagramming]({{< relref "skills/architecture-diagramming.md" >}}) | Generate Mermaid architecture diagrams showing system components, layers, and data flows. |
+| [Dependency Mapping]({{< relref "skills/dependency-mapping.md" >}}) | Generate Mermaid dependency graphs showing issue relationships, blocking chains, and critical paths. |
+| [Mermaid Diagrams]({{< relref "skills/mermaid-diagrams.md" >}}) | Guide for creating syntactically correct Mermaid diagrams that render properly on GitHub. |
 
 ## How to use it
 

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = 'https://britt.github.io/claude-code-skills/'
+baseURL = 'https://britt.github.io/agent-skills/'
 languageCode = 'en-us'
 title = 'Agent Skills'
 theme = 'paper'
@@ -6,7 +6,7 @@ copyright = '© 2026 Snugglebear Team Company'
 
 [params]
   color = 'linen'
-  github = 'britt/claude-code-skills'
+  github = 'britt/agent-skills'
   avatar = ''
   name = 'Agent Skills'
   bio = 'A collection of skills to enhance AI-assisted development workflows'


### PR DESCRIPTION
## Summary
- Every skill link on the homepage, skill-list, and project-foundations pages used root-absolute paths that didn't account for the GitHub Pages baseURL subpath, so all of them 404'd. Switched to Hugo `relref` shortcodes, which resolve correctly and fail the build if a target page ever goes missing.
- `project-foundations.md` had a second bug: its `./slug/` relative links resolved one directory too deep, also fixed via `relref`.
- `hugo.toml`'s `baseURL` and `github` param still referenced the old `claude-code-skills` repo name; updated to `agent-skills` to match the repo rename.

## Test plan
- [x] Built the site locally with Hugo v0.145.0 (matching CI) and confirmed all 39 pages render
- [x] Programmatically checked all 521 hrefs in the built output — 0 broken internal links
- [x] Verified all 5 external links return HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)