### PR TITLE
Rework setting-up-a-project for multi-agent use; add project status step to working-on-an-issue

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "britt",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "A collection of skills for Claude Code to enhance AI-assisted development workflows",
   "owner": {
     "name": "Britt Crawford",
@@ -11,7 +11,7 @@
     {
       "name": "agent-skills",
       "description": "All skills bundled together for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "author": {
         "name": "Britt Crawford",
         "email": "britt@brittcrawford.com"
@@ -23,7 +23,7 @@
     {
       "name": "project-foundations",
       "description": "A curated bundle for taking a new project from concept to a diagrammed, story-driven plan: project setup, issue decomposition, user stories, verification plans, and architecture/dependency/Mermaid diagrams",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "author": {
         "name": "Britt Crawford",
         "email": "britt@brittcrawford.com"
@@ -255,7 +255,7 @@
     {
       "name": "working-on-an-issue",
       "description": "Hands-off workflow for implementing GitHub issues: scoped recon, verification-first planning, TDD implementation, and a PR that serves as the approval gate",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "Britt Crawford"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-skills",
   "description": "Skills for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": {
     "name": "Britt Crawford",
     "email": "britt@brittcrawford.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-skills",
   "description": "Skills for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": {
     "name": "Britt Crawford",
     "email": "britt@brittcrawford.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "agent-skills",
   "displayName": "Agent Skills",
   "description": "Skills for AI-assisted development: project setup, product specs, user stories, verification plans, daily planning, and more",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": {
     "name": "Britt Crawford",
     "email": "britt@brittcrawford.com"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Guidelines for contributing to this skills repository.
 claude-code-skills/
 ├── README.md                 # Installation and usage guide
 ├── CONTRIBUTING.md           # This file
-├── sync-agents-skills.sh     # Keeps .agents/skills/ symlinks in sync with skills/
+├── sync-agents-skills.sh     # Keeps .agents/skills/ symlinks and the rules/ mirror in sync with skills/
 ├── .claude-plugin/
 │   ├── marketplace.json      # Claude Code plugin marketplace configuration
 │   └── plugin.json           # Claude Code plugin manifest (full bundle)
@@ -91,6 +91,8 @@ Optional elements:
 ### 3. Link into .agents/skills/ (Required)
 
 Run `./sync-agents-skills.sh` to add the `.agents/skills/<name>` symlink for your new skill (and clean up any stale ones). This is what makes the skill discoverable by Codex CLI, OpenCode, and Cursor — commit the symlink, not a copy of the file.
+
+The same script refreshes `rules/`, which mirrors rule sets bundled inside skills so they stay fetchable by raw URL. Edit the copy inside the skill; never edit `rules/` directly. Skills must stay self-contained — single-skill installs use `"source": "./skills/<name>"`, so a symlink out of the skill directory would dangle.
 
 ### 4. Update Marketplace (Required)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A collection of skills for coding agents to enhance AI-assisted development work
 | Skill | Description | Claude Code | Claude.ai |
 |-------|-------------|:-----------:|:---------:|
 | **sgai-goal** | Compose GOAL.md files for SGAI workspaces through interactive conversation | * | |
-| **setting-up-a-project** | Author CLAUDE.md with project purpose, tech stack, and development practices | * | |
+| **setting-up-a-project** | Author CLAUDE.md and AGENTS.md with project purpose, tech stack, and development practices | * | |
 | **working-on-an-issue** | Implement a GitHub issue hands-off, with scoped recon and a PR as the approval gate | * | |
 | **project-analysis** | Analyze project codebase structure, architecture, key files, and dependencies | * | * |
 | **project-planning** | Orchestrate end-to-end project planning with issues, diagrams, dependencies, and timelines | * | * |
@@ -160,7 +160,7 @@ done
 
 Codex CLI also reads `~/.codex/AGENTS.md` / project `AGENTS.md`, OpenCode reads `AGENTS.md` and natively falls back to `.claude/skills/`, and Cursor also reads `.cursor/skills/` — so a plain `git clone` into any of those tool-specific directories works too. Restart the tool after installation to load new skills.
 
-**Note:** Some skills (like `sgai-goal` and `setting-up-a-project`) reference Claude Code-specific tooling (e.g. `CLAUDE.md`, `TodoWrite`) and may need minor adaptation to work identically in other tools; most skills are plain instructional markdown and are unaffected. Granular per-skill plugin installs (like `/plugin install architecture-diagramming@britt` for Claude Code) aren't set up for Codex/Cursor yet — only the two bundles above; use the manual `.agents/skills/` installation for individual-skill granularity on those tools.
+**Note:** Some skills (like `sgai-goal`) reference Claude Code-specific tooling (e.g. `CLAUDE.md`, `TodoWrite`) and may need minor adaptation to work identically in other tools; most skills are plain instructional markdown and are unaffected. `setting-up-a-project` is multi-agent aware — it writes both a `CLAUDE.md` and an `AGENTS.md` adapted for Codex CLI, OpenCode, and Cursor. Granular per-skill plugin installs (like `/plugin install architecture-diagramming@britt` for Claude Code) aren't set up for Codex/Cursor yet — only the two bundles above; use the manual `.agents/skills/` installation for individual-skill granularity on those tools.
 
 ### Claude.ai (Web and iOS)
 
@@ -183,27 +183,28 @@ Skills can be added to Claude.ai projects as project knowledge:
 
 ## Rules
 
-The `rules/` directory contains reusable rule sets that can be copied into your project's CLAUDE.md.
+The `rules/` directory contains reusable rule sets that can be dropped into your project.
 
 ### TDD.rules.md
 
-Strict Test-Driven Development rules for Claude. Used by the `setting-up-a-project` skill.
+Strict Test-Driven Development rules for coding agents. Used by the `setting-up-a-project` skill, which references them from both `CLAUDE.md` and `AGENTS.md`.
 
 **Key rules:**
 - No production code without a failing test first (RED-GREEN-REFACTOR)
-- 90%+ test coverage required on all metrics
+- 90%+ test coverage required on all metrics (configurable)
 - Violations mean delete and start over
-- Commit early, commit often (after every TDD cycle)
 - Tasks aren't complete until tests pass, build succeeds, and no linter errors
 
-**Usage:** The `setting-up-a-project` skill copies this file verbatim into your project's CLAUDE.md. You can also copy it manually:
+**Usage:** The `setting-up-a-project` skill copies this file to your project root and fills in its placeholders, then references it from CLAUDE.md as `@TDD.rules.md`. You can also copy it manually:
 
 ```bash
-curl -o CLAUDE.md \
+curl -o TDD.rules.md \
   https://raw.githubusercontent.com/britt/agent-skills/main/rules/TDD.rules.md
 ```
 
-Fill in the placeholder commands (`<test command>`, `<build command>`, etc.) for your tech stack.
+Replace every `{{PLACEHOLDER}}` (`{{TEST_COMMAND}}`, `{{BUILD_COMMAND}}`, coverage thresholds, test file convention) with values for your tech stack.
+
+`rules/TDD.rules.md` is a mirror. The canonical copy lives at `skills/setting-up-a-project/TDD.rules.md` so single-skill installs stay self-contained; `./sync-agents-skills.sh` refreshes the mirror.
 
 ## Documentation
 

--- a/bundles/project-foundations/.claude-plugin/plugin.json
+++ b/bundles/project-foundations/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-foundations",
   "description": "A curated bundle for taking a new project from concept to a diagrammed, story-driven plan: project setup, issue decomposition, user stories, verification plans, and architecture/dependency/Mermaid diagrams",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "Britt Crawford",
     "email": "britt@brittcrawford.com"

--- a/bundles/project-foundations/.codex-plugin/plugin.json
+++ b/bundles/project-foundations/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-foundations",
   "description": "A curated bundle for taking a new project from concept to a diagrammed, story-driven plan: project setup, issue decomposition, user stories, verification plans, and architecture/dependency/Mermaid diagrams",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "Britt Crawford",
     "email": "britt@brittcrawford.com"

--- a/bundles/project-foundations/.cursor-plugin/plugin.json
+++ b/bundles/project-foundations/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "project-foundations",
   "displayName": "Project Foundations",
   "description": "A curated bundle for taking a new project from concept to a diagrammed, story-driven plan: project setup, issue decomposition, user stories, verification plans, and architecture/dependency/Mermaid diagrams",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "Britt Crawford",
     "email": "britt@brittcrawford.com"

--- a/rules/TDD.rules.md
+++ b/rules/TDD.rules.md
@@ -1,4 +1,10 @@
-# Rules for Claude
+# Rules for the Coding Agent
+
+> **This file is a template.** Every `{{PLACEHOLDER}}` must be replaced with a real
+> value before it lands in a project. A shipped `{{TEST_COMMAND}}` is a bug.
+>
+> Referenced by `CLAUDE.md` and `AGENTS.md`. It applies to every agent working in
+> the repo, whichever entry file brought you here.
 
 ## ABSOLUTE RULES - NO EXCEPTIONS
 
@@ -26,17 +32,17 @@ If ANY of these occur, you MUST delete the code and start over:
 
 ### 3. Test Coverage Requirements
 
-- **Minimum 90%** coverage on ALL metrics:
-  - Lines: 90%+
-  - Functions: 90%+
-  - Branches: 85%+
-  - Statements: 90%+
+- **Minimum {{COVERAGE_THRESHOLD}}%** coverage on ALL metrics:
+  - Lines: {{COVERAGE_THRESHOLD}}%+
+  - Functions: {{COVERAGE_THRESHOLD}}%+
+  - Branches: {{BRANCH_COVERAGE_THRESHOLD}}%+
+  - Statements: {{COVERAGE_THRESHOLD}}%+
 - Coverage below threshold = Implementation incomplete
 - Untested code = Code that shouldn't exist
 
 ### 4. Implementation Order
 
-Follow the plan tasks listed in @IMPLEMENTATION_PLAN.md in EXACT order.
+If the project has an `IMPLEMENTATION_PLAN.md`, follow its tasks in EXACT order.
 
 ### 5. Before Writing ANY Code
 
@@ -49,10 +55,10 @@ If ANY answer is "no" → STOP. Write the test first.
 
 ### 6. Test File Structure
 
-For every production file, there MUST be a corresponding test file:
-- `src/example.ts` → `src/__tests__/example.test.ts`
-- `src/another-example.ts` → `src/__tests__/another-example.test.ts`
-- `src/causes_edge_cases.ts` → `src/__tests__/causes_edge_cases.test.ts`
+For every production file, there MUST be a corresponding test file. This project's
+convention:
+
+{{TEST_FILE_CONVENTION}}
 
 ### 7. Task Completion Requirements
 
@@ -60,8 +66,9 @@ For every production file, there MUST be a corresponding test file:
 - ✅ ALL tests pass (100% green)
 - ✅ Build succeeds with ZERO errors
 - ✅ NO linter errors or warnings
-- ✅ Coverage meets minimum thresholds (90%+)
+- ✅ Coverage meets minimum thresholds ({{COVERAGE_THRESHOLD}}%+)
 - ✅ Progress documented in PROGRESS.md
+- ✅ Work committed, following the Git Commit Rules in CLAUDE.md / AGENTS.md
 
 A task with failing tests, build errors, or linter warnings is INCOMPLETE. Period.
 
@@ -90,82 +97,42 @@ Format:
 - Notes: [any relevant notes]
 ```
 
-### 9. Git Commits - Commit Early, Commit Often
-
-**MANDATORY RULE**: COMMIT EARLY, COMMIT OFTEN
-
-- **Commit after EACH successful TDD cycle**:
-  - ✅ After RED-GREEN-REFACTOR cycle completes
-  - ✅ After each test file is created
-  - ✅ After each module implementation
-  - ✅ After fixing bugs or issues
-  - ✅ After updating documentation
-
-- **Frequency Requirements**:
-  - Minimum: After each completed subtask
-  - Maximum: No more than 30 minutes without a commit
-  - Never have more than one feature in a single commit
-
-- **Each commit MUST**:
-  - Have failing tests written first
-  - Pass all tests
-  - Build successfully
-  - Have no linter errors
-  - Meet coverage requirements (if code was added)
-  - Have progress documented
-  - Include clear commit message mentioning TDD
-
-- **Commit Message Format**:
-  ```
-  type(scope): brief description
-
-  - RED: What tests were written first
-  - GREEN: What minimal code was added
-  - Status: X tests passing, build successful
-  - Coverage: X% (if applicable)
-  ```
-
-- **Benefits of Frequent Commits**:
-  - Easy rollback if something breaks
-  - Clear history of TDD progression
-  - Smaller, reviewable changes
-  - Proof of TDD discipline
-
 ## Development Workflow
 
 For EACH feature/function:
 
 ```
 1. Write test file or add test case
-2. Run: <test command>
+2. Run: {{TEST_COMMAND}}
 3. See RED (test fails)
 4. Understand WHY it fails
 5. Write minimal production code
-6. Run: <test command>
+6. Run: {{TEST_COMMAND}}
 7. See GREEN (test passes)
 8. Refactor if needed
-9. Run: <test command> (stays green)
-10. Check coverage: <coverage command>
-11. Repeat for next feature
+9. Run: {{TEST_COMMAND}} (stays green)
+10. Check coverage: {{COVERAGE_COMMAND}}
+11. Commit (see the Git Commit Rules in CLAUDE.md / AGENTS.md)
+12. Repeat for next feature
 ```
 
 ## Commands You'll Use Constantly
 
 ```bash
 # Watch mode - keep this running ALWAYS
-<test command>
+{{TEST_WATCH_COMMAND}}
 
 # Run once
-<test command>
+{{TEST_COMMAND}}
 
 # Check coverage
-<coverage command>
+{{COVERAGE_COMMAND}}
 
 # Build - MUST succeed before task is complete
-<build command>
+{{BUILD_COMMAND}}
 
 # Check for Linter errors
-<linter command>
+{{LINT_COMMAND}}
 ```
 
 ## Red Flags - STOP Immediately
@@ -187,7 +154,7 @@ If you catch yourself:
 - Tests are not added after
 - Tests DRIVE the implementation
 - If it's not tested, it doesn't exist
-- Coverage below 90% = unfinished work
+- Coverage below {{COVERAGE_THRESHOLD}}% = unfinished work
 
 ## Accountability Check
 
@@ -196,10 +163,11 @@ Before marking ANY task complete, verify:
 2. ✓ Test failed first?
 3. ✓ Minimal code to pass?
 4. ✓ All tests green?
-5. ✓ Coverage maintained (90%+)?
-6. ✓ Build succeeds (`<build command>`)?
+5. ✓ Coverage maintained ({{COVERAGE_THRESHOLD}}%+)?
+6. ✓ Build succeeds (`{{BUILD_COMMAND}}`)?
 7. ✓ No linter errors?
 8. ✓ Progress documented in PROGRESS.md?
+9. ✓ Work committed?
 
 Missing ANY ✓ = Task is NOT complete. Fix it first.
 

--- a/site/content/skills/setting-up-a-project.md
+++ b/site/content/skills/setting-up-a-project.md
@@ -3,7 +3,7 @@ title: "Setting Up a Project"
 description: "Author CLAUDE.md with project purpose, tech stack, and development practices"
 ---
 
-Author a CLAUDE.md file that defines your project's purpose, tech stack, and development practices before any code is written. It interviews you one question at a time to clarify goals, choose a tech stack, and establish development conventions before scaffolding code.
+Author the instruction files that define your project's purpose, tech stack, and development practices before any code is written — CLAUDE.md for Claude Code and a separately tuned AGENTS.md for Codex CLI, OpenCode, and Cursor. It surveys the repository first, then interviews you one question at a time to fill the gaps and establish development conventions before scaffolding code.
 
 ### Installation
 
@@ -38,14 +38,26 @@ Use this skill when:
 
 ## Features
 
+**Repository survey before the interview**
+Reads manifests, lockfiles, and CI workflows to detect your stack, then asks you to confirm instead of interrogating you about things the repo already answers. Merges into a thin existing CLAUDE.md rather than overwriting it.
+
 **Guided interview for project definition**
 Asks one question at a time to define the project's purpose and align on what you are building, rather than dumping questions all at once.
 
 **Tech stack with sensible defaults**
 Establishes the tech stack with sensible defaults so you have a clear starting point.
 
+**A commands section that actually runs**
+Records the exact install, test, coverage, build, lint, and run commands, then runs each one before committing so the documentation cannot drift from reality on day one.
+
 **Development practices and git workflow**
-Copies test-driven development rules and git practices (including "commit early, commit often") verbatim into CLAUDE.md, along with pull request rules covering merge commits and issue-closing references.
+Installs test-driven development rules as a project-root `TDD.rules.md` with your commands and coverage thresholds filled in, referenced from CLAUDE.md so it stays short. Copies commit rules verbatim, and settles branching, merge style, and issue references with you rather than dictating them.
+
+**A CLAUDE.md and an AGENTS.md that are actually different**
+Writes both, rather than symlinking one to the other. CLAUDE.md uses Claude Code's `@` imports and tool names; AGENTS.md replaces them with an explicit required-reading list and a condensed inline set of non-negotiables, because nothing auto-loads in Codex CLI, OpenCode, or Cursor.
+
+**Agent harness configuration**
+Offers a `.claude/settings.json` permission allowlist built from your project's own commands, and covers the other agents with an in-prose rule instead of inventing config for tools whose schemas move.
 
 **Verification plan integration**
 Creates a verification plan by invoking the Writing Verification Plans skill.

--- a/site/content/skills/setting-up-a-project.md
+++ b/site/content/skills/setting-up-a-project.md
@@ -1,6 +1,6 @@
 ---
 title: "Setting Up a Project"
-description: "Author CLAUDE.md with project purpose, tech stack, and development practices"
+description: "Author CLAUDE.md and AGENTS.md with project purpose, tech stack, and development practices"
 ---
 
 Author the instruction files that define your project's purpose, tech stack, and development practices before any code is written — CLAUDE.md for Claude Code and a separately tuned AGENTS.md for Codex CLI, OpenCode, and Cursor. It surveys the repository first, then interviews you one question at a time to fill the gaps and establish development conventions before scaffolding code.

--- a/site/content/skills/working-on-an-issue.md
+++ b/site/content/skills/working-on-an-issue.md
@@ -48,6 +48,9 @@ Not every issue qualifies. Epic-sized issues that bundle independent changes are
 
 ## Features
 
+**Updates linked GitHub Projects automatically**
+Before recon starts, the agent checks whether the issue belongs to any GitHub Projects (v2) via the GraphQL API. If it's tracked in one or more, it moves the issue to an "in progress" style status in every one of them, so project boards reflect that work has begun. Missing project scope or an unmatched status option doesn't block the workflow — it's noted as a caveat and the agent moves on.
+
 **Hands-off by default — the PR is the approval gate**
 There are no approval checkpoints during the work. Plans are saved to `docs/plans/issue-<number>-plan.md` and implementation proceeds immediately; the developer reviews the finished work on the pull request, where every assumption and verification result is recorded.
 

--- a/skills/setting-up-a-project/SKILL.md
+++ b/skills/setting-up-a-project/SKILL.md
@@ -1,21 +1,57 @@
 ---
 name: setting-up-a-project
-description: Use when setting up a new Claude Code project, when a repo has no CLAUDE.md, or when starting work on an empty codebase - interviews the user and authors a CLAUDE.md covering project purpose, tech stack, TDD rules, and development practices
+description: Use when setting up a new project for coding agents, when a repo has no CLAUDE.md or AGENTS.md, or when starting work on an empty codebase - surveys the repo, interviews the user, and authors CLAUDE.md plus an AGENTS.md tuned for Codex CLI, OpenCode, and Cursor, covering project purpose, tech stack, commands, TDD rules, and development practices
 ---
 
 # Setting up a Project
 
 ## Overview
 
-Help Claude author a CLAUDE.md file that defines a project's purpose, development practices, and tech stack before writing code.
+Author the instruction files that define a project's purpose, commands, and development practices before writing code: `CLAUDE.md` for Claude Code, `AGENTS.md` for Codex CLI, OpenCode, and Cursor, plus the rule files both of them lean on.
 
 **Core principle:** A well-configured project prevents rework and ensures consistency. Establishing guardrails upfront helps Claude Code work reliably, produce high-quality code, and avoid doom loops where code is written, broken, and rewritten repeatedly.
 
 **When NOT to use:** an established repo that already has a mature CLAUDE.md - review and refine the existing file instead.
 
+**Track each numbered step below as a todo** (`TodoWrite` in Claude Code, your plan or todo tool elsewhere).
+
+**Commit after each section the user confirms** - one commit per section, throughout every step below.
+
 ## The Process
 
-### Define the Project Purpose
+### 1. Survey the Repository
+
+Read what the repo already says about itself before asking anything. Never ask a question the files answer.
+
+```bash
+ls -a                       # layout, and whether CLAUDE.md / AGENTS.md / .claude/ exist
+cat README.md 2>/dev/null
+```
+
+Detect the stack from manifests and lockfiles:
+
+| Evidence | What it tells you |
+|----------|-------------------|
+| `package.json` + `pnpm-lock.yaml` / `package-lock.json` / `yarn.lock` / `bun.lockb` | Language, package manager, scripts, test and lint tooling |
+| `pyproject.toml` / `uv.lock` / `requirements.txt` | Python packaging and tool config |
+| `go.mod` | Go module path and version |
+| `Cargo.toml` | Rust crate and workspace layout |
+| `Makefile` / `Taskfile.yml` / `justfile` | The commands people actually run |
+| `.github/workflows/*.yml` | The commands CI actually runs - the most reliable source |
+| `Dockerfile` / `fly.toml` / `wrangler.jsonc` / `serverless.yml` | Deployment target |
+
+Then **confirm rather than interrogate**: "This looks like a TypeScript CLI on pnpm with Vitest and ESLint - right?" Ask only about what the repo cannot tell you.
+
+Handle what you find:
+
+- **Empty repo, no manifests** - nothing to survey. Go to step 2 and ask everything.
+- **CLAUDE.md or AGENTS.md exists but is thin** - merge into it. Read it first, keep the user's existing wording, add only the missing sections. Never overwrite a file you have not read.
+- **CLAUDE.md exists and is mature** - stop and offer to review and refine it instead of running this skill.
+- **AGENTS.md is a symlink to CLAUDE.md** - replace it with a real file in step 7. A symlink cannot carry the adaptations the other agents need.
+
+Also ask which agents will work in this repo (Claude Code, Codex CLI, OpenCode, Cursor). Step 7 writes `AGENTS.md` for the latter three; write it by default unless the user says Claude Code is the only agent that will ever touch the project.
+
+### 2. Define the Project Purpose
 
 Ask questions to determine:
 
@@ -23,8 +59,7 @@ Ask questions to determine:
 2. **What problem does this solve?** Understand the pain point, who experiences it, and why existing solutions are inadequate.
 3. **How will it work?** Get a high-level explanation of the approach or mechanism.
 
-Then update CLAUDE.md. Document the answers in CLAUDE.md under a `## Project Overview` section.
-Here's a template:
+Document the answers in CLAUDE.md under a `## Project Overview` section:
 
 ```markdown
 ## Project Overview
@@ -40,11 +75,9 @@ Home cooks waste food and time deciding what to make. Existing recipe apps assum
 A local ingredient inventory is matched against a recipe index. The tool ranks recipes by pantry coverage and prints the top matches along with a shopping list for any missing ingredients.
 ```
 
-## Define the Tech Stack
+### 3. Define the Tech Stack
 
-Ask the user about each of these areas. Suggest sensible defaults based on the language/runtime.
-
-### Questions to Ask
+Ask about each area the survey did not already answer. Suggest defaults based on the language and runtime.
 
 1. **Language and runtime** - What programming language? What version/runtime?
 2. **Deployment target** - Where will this run? (CLI, web server, serverless, container, browser, etc.)
@@ -53,11 +86,9 @@ Ask the user about each of these areas. Suggest sensible defaults based on the l
 5. **Build tools** - How will the project be built/compiled?
 6. **Linting and formatting** - What tools enforce code style?
 7. **Key libraries** - Any specific libraries or frameworks required?
-8. **Unique concerns** - Any other technical requirements specific to this project? (e.g., database, auth, external APIs)
+8. **Unique concerns** - Any other technical requirements? (database, auth, external APIs)
 
-### Suggested Defaults
-
-When suggesting defaults, base them on the language:
+Defaults by language:
 
 | Language | Package Manager | Testing | Linting | Build |
 |----------|-----------------|---------|---------|-------|
@@ -66,10 +97,7 @@ When suggesting defaults, base them on the language:
 | Go | go modules | go test | golangci-lint | go build |
 | Rust | cargo | cargo test | clippy | cargo build |
 
-Adjust suggestions based on deployment target and project needs.
-
-Document the output in CLAUDE.md under a `## Tech Stack` section.
-Here's a template:
+Adjust suggestions based on deployment target and project needs. Document the result under `## Tech Stack`:
 
 ```markdown
 ## Tech Stack
@@ -83,32 +111,83 @@ Here's a template:
 - **Key Libraries**: [List of essential libraries]
 ```
 
-After defining the tech stack:
-- confirm with the user
-- write the choices to `CLAUDE.md`
-- commit the file to git
+### 4. Record the Commands
 
-## Establish Development Practices
+The Commands section is the most-used part of a CLAUDE.md - Claude reads it before every test run, build, and lint. Get exact, runnable strings, copied verbatim from `package.json` scripts, the Makefile, or the CI workflow when those exist.
 
-### TDD Rules (Mandatory)
+```markdown
+## Commands
+
+| Task | Command |
+|------|---------|
+| Install | `pnpm install` |
+| Test (once) | `pnpm test` |
+| Test (watch) | `pnpm test --watch` |
+| Coverage | `pnpm test --coverage` |
+| Build | `pnpm build` |
+| Lint | `pnpm lint` |
+| Format | `pnpm format` |
+| Typecheck | `pnpm typecheck` |
+| Run locally | `pnpm dev` |
+```
+
+Omit rows that do not apply. These values fill the placeholders in `TDD.rules.md` (step 5) and the permission allowlist (step 7), so get them right here.
+
+### 5. Establish Development Practices
+
+#### TDD Rules (Mandatory)
 
 TDD is non-negotiable for all projects set up with this skill.
-Read the bundled `TDD.rules.md` file (in this skill's directory) and copy it verbatim into `CLAUDE.md`.
-If the bundled file is missing, fall back to fetching `https://raw.githubusercontent.com/britt/claude-code-skills/refs/heads/main/rules/TDD.rules.md`.
 
-### Git Practices
+1. Confirm the coverage thresholds with the user. Defaults: 90% lines, functions, and statements; 85% branches. Record whatever they choose.
+2. Ask how test files are named and located in this stack (for example `src/example.ts` → `src/__tests__/example.test.ts`, or Go's `example_test.go` beside the source).
+3. Copy the bundled `TDD.rules.md` (in this skill's directory) to the **project root** as `TDD.rules.md`. Do not paste it into CLAUDE.md - it is over 200 lines, and CLAUDE.md loads into every session.
+4. Replace every `{{PLACEHOLDER}}` in the copy:
 
-Ask the user about their preferred git workflow, then document it in CLAUDE.md:
+   | Placeholder | Value |
+   |-------------|-------|
+   | `{{TEST_COMMAND}}` | Test (once), from step 4 |
+   | `{{TEST_WATCH_COMMAND}}` | Test (watch), from step 4 |
+   | `{{COVERAGE_COMMAND}}` | Coverage, from step 4 |
+   | `{{BUILD_COMMAND}}` | Build, from step 4 |
+   | `{{LINT_COMMAND}}` | Lint, from step 4 |
+   | `{{COVERAGE_THRESHOLD}}` | Lines/functions/statements threshold |
+   | `{{BRANCH_COVERAGE_THRESHOLD}}` | Branch threshold |
+   | `{{TEST_FILE_CONVENTION}}` | The naming and location rule, with two or three concrete examples |
+
+5. Reference it from CLAUDE.md under `## Development Practices`:
+
+```markdown
+### Test-Driven Development
+
+TDD is mandatory. **Read `TDD.rules.md` before writing any code.**
+
+@TDD.rules.md
+```
+
+The `@` line is a Claude Code auto-import. The sentence above it is what makes the rules reachable in every other agent, which read the file as plain text - never rely on `@` alone.
+
+If the bundled file is missing, fall back to fetching `https://raw.githubusercontent.com/britt/agent-skills/refs/heads/main/rules/TDD.rules.md`.
+
+**Verify no placeholder survives:** `grep -n '{{' TDD.rules.md` must return nothing.
+
+#### Commit Rules (CRITICAL)
+
+**This rule is non-negotiable.** Read the bundled `git-commit-rules.md` file (in this skill's directory) and copy it verbatim into `CLAUDE.md`, and into `AGENTS.md` in step 7. It is short, and it is the single home for commit discipline - `TDD.rules.md` points here rather than restating it.
+
+#### Git and Pull Request Workflow
+
+Ask about each, and offer the default:
 
 1. **Branching strategy** - Feature branches, trunk-based, or git worktrees?
 2. **Branch naming** - Convention for naming branches (e.g., `feature/`, `fix/`, `chore/`)
 3. **Worktrees** - If using worktrees, establish conventions for worktree location and naming
+4. **Merge style** - Default: merge commits, never squash. Confirm before recording.
+5. **Issue references** - Default: when working an issue, the PR description must note that the PR closes that issue number. Confirm before recording.
 
-### Commit Early, Commit Often (CRITICAL)
+Document the answers under `## Development Practices`.
 
-**This rule is non-negotiable.** Read the bundled `git-commit-rules.md` file (in this skill's directory) and copy it verbatim into `CLAUDE.md`.
-
-### GitHub Actions Rules (if the project uses GitHub Actions)
+#### GitHub Actions Rules (if the project uses GitHub Actions)
 
 If the project uses, or will use, GitHub Actions for CI/CD, apply this rule whenever authoring or editing workflow files:
 
@@ -122,42 +201,200 @@ Document this rule in CLAUDE.md under a `## CI/CD Practices` section (only if th
 - Never use GitHub Actions pinned to the deprecated Node 20 runtime. Always use the latest major version of each action.
 ```
 
-### Pull Request Rules
-YOU MUST follow these rules when creating a pull request. 
+### 6. Document the Working Environment
 
-- Use a merge commit do not squash commits. 
-- If you are working on an issue make sure to note in the PR description that this PR closes the issue number.
+Three short sections that save an agent from guessing:
 
+```markdown
+## Repository Layout
 
-### Verification Plan
+- `src/` - application code
+- `src/__tests__/` - tests, mirroring `src/`
+- `scripts/` - build and release tooling
 
-Use the `writing-verification-plans` skill (if available) to create a verification plan. 
-This produces a VERIFICATION_PLAN.md file that should be linked in CLAUDE.md as shown below:
+## Environment
+
+Copy `.env.example` to `.env` and fill in the values. Never commit `.env` or any
+credential. Required variables: `DATABASE_URL`, `API_KEY`.
+
+## Boundaries
+
+Do not edit by hand:
+- `dist/`, `*.generated.ts` - generated output; change the generator instead
+- `pnpm-lock.yaml` - update via the package manager
+```
+
+Ask what is generated, vendored, or otherwise off-limits, and what secrets the project needs. Omit any section that has no content - an empty heading is worse than none.
+
+### 7. Write the Files Each Agent Reads
+
+#### AGENTS.md (Codex CLI, OpenCode, Cursor)
+
+Claude Code reads `CLAUDE.md`. Codex CLI, OpenCode, and Cursor read `AGENTS.md`. Write both.
+
+**Do not symlink them together.** They describe the same project but they are not the same document: `CLAUDE.md` leans on auto-imports and Claude Code's tool names, and neither survives the trip to another agent.
+
+How `AGENTS.md` differs:
+
+| Concern | CLAUDE.md | AGENTS.md |
+|---------|-----------|-----------|
+| Deep rule sets | `@TDD.rules.md` auto-import | A **Required Reading** list instructing the agent to open the files itself - nothing auto-loads |
+| Non-negotiables | Carried by the imported rule files | Condensed inline at the top, so the critical rules are present even if the agent never opens another file |
+| Todo tracking | `TodoWrite` by name | "your plan or todo tool" |
+| Permissions | Points at `.claude/settings.json` | An inline rule: run the Commands table freely, ask before anything else |
+| Shape | Terse; imports carry the weight | Flatter and self-contained |
+
+Template:
+
+```markdown
+# <Project Name> - Agent Instructions
+
+Read this file before making any change. It applies to every agent working in this repo.
+
+## Required Reading
+
+These files are not loaded automatically. Open them yourself before writing code:
+
+- `TDD.rules.md` - test-driven development rules. Mandatory, no exceptions.
+- `VERIFICATION_PLAN.md` - how to prove a change actually works.
+
+## Non-Negotiables
+
+1. No production code without a failing test first. Full rules in `TDD.rules.md`.
+2. Commit after every RED-GREEN-REFACTOR cycle. Never leave 30 minutes of work uncommitted.
+3. A task is not done until tests pass, the build succeeds, and the linter is clean.
+4. Run the commands in the Commands table freely. Ask first before anything that
+   installs software, writes outside the repo, or reaches the network.
+5. Track multi-step work in your plan or todo tool as you go.
+
+## Project Overview
+## Tech Stack
+## Commands
+## Repository Layout
+## Environment
+## Development Practices
+## CI/CD Practices
+## Boundaries
+
+## Maintaining This File
+
+`CLAUDE.md` and `AGENTS.md` describe the same project. When a project fact changes -
+a command, the stack, the layout, a boundary - update both in the same commit.
+```
+
+The sections from `## Project Overview` down carry the same content as `CLAUDE.md`, written out in full rather than referenced. Write `## Development Practices` inline here: the git and PR workflow from step 5, plus the commit rules, with no `@` references anywhere in the file.
+
+If a tool does not pick `AGENTS.md` up, check that tool's current documentation for its instruction-file path rather than guessing at one.
+
+#### .claude/settings.json (Claude Code, optional)
+
+Offer to create `.claude/settings.json` with an allowlist for the commands from step 4, so routine work does not trigger a prompt on every run. Offer, do not impose - ask before writing.
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm test:*)",
+      "Bash(pnpm lint:*)",
+      "Bash(pnpm build:*)"
+    ]
+  }
+}
+```
+
+Only list read-only or build/test commands. Never allowlist anything destructive or anything that publishes.
+
+This file is Claude Code-specific. The other three agents configure permissions their own way and their schemas move - do not invent a `codex`, `opencode`, or `cursor` config file. `AGENTS.md` rule 4 above covers them in prose instead.
+
+### 8. Write the Verification Plan
+
+Use the `writing-verification-plans` skill to create a verification plan. If it is unavailable, write `VERIFICATION_PLAN.md` covering the acceptance scenarios that prove the project works against real systems, with success criteria and a pass/fail log.
+
+Link it from CLAUDE.md:
 
 ```markdown
 ## Verification
 
-See @VERIFICATION_PLAN.md for acceptance testing procedures.
+Acceptance testing procedures: read `VERIFICATION_PLAN.md`.
+
+@VERIFICATION_PLAN.md
 ```
 
-## After Setting Up
+In `AGENTS.md` it is already covered by the Required Reading list - no `@` line there.
 
-* Write the `CLAUDE.md` file
-* Use elements-of-style:writing-clearly-and-concisely skill if available
-* Commit the `CLAUDE.md` to git
-* Ask if the user would like to start brainstorming requirements or an implementation plan. Use the `superpowers:brainstorming` skill (if available) or the `superpowers:writing-plans` skill (if available) if they say yes.
+### 9. Verify, Then Finish
+
+Documentation that does not run is worse than none. Before the final commit:
+
+1. **Run every command in the Commands section.** Fix any that fail or do not exist.
+2. **Check for unfilled placeholders:** `grep -n '{{' CLAUDE.md AGENTS.md TDD.rules.md` must return nothing.
+3. **Check `AGENTS.md` carries no Claude Code-isms:** `grep -n '@\|TodoWrite\|\.claude/' AGENTS.md` should return nothing but ordinary prose. An `@TDD.rules.md` line that leaked in is dead text in Codex CLI, OpenCode, and Cursor.
+4. **Check the two files agree** on commands, stack, layout, and boundaries. They are separate documents, so nothing enforces this but you.
+5. **Confirm `AGENTS.md` is a real file, not a symlink:** `test -L AGENTS.md && echo "symlink - replace it"`.
+6. **Re-read both files end to end** for contradictions between sections.
+7. Use the `elements-of-style:writing-clearly-and-concisely` skill if available.
+8. Commit.
+9. Ask if the user would like to start brainstorming requirements or an implementation plan. Use the `superpowers:brainstorming` skill (if available) or the `superpowers:writing-plans` skill (if available) if they say yes.
+
+## The Finished Files
+
+Sections in this order. Omit any that do not apply.
+
+```markdown
+CLAUDE.md                 (Claude Code)
+# <Project Name>
+
+## Project Overview       (problem, approach)
+## Tech Stack
+## Commands
+## Repository Layout
+## Environment
+## Development Practices  (TDD → read + @TDD.rules.md, commit rules, git/PR workflow)
+## CI/CD Practices        (only if GitHub Actions)
+## Boundaries
+## Verification           (read + @VERIFICATION_PLAN.md)
+```
+
+```markdown
+AGENTS.md                 (Codex CLI, OpenCode, Cursor)
+# <Project Name> - Agent Instructions
+
+## Required Reading       (TDD.rules.md, VERIFICATION_PLAN.md - no @ imports)
+## Non-Negotiables        (condensed inline; nothing auto-loads here)
+## Project Overview       ┐
+## Tech Stack             │
+## Commands               │ same content as CLAUDE.md,
+## Repository Layout      │ written out in full
+## Environment            │
+## Development Practices  │ (inline, not referenced)
+## CI/CD Practices        │
+## Boundaries             ┘
+## Maintaining This File  (change one, change both, same commit)
+```
+
+Alongside them: `TDD.rules.md`, `VERIFICATION_PLAN.md`, and optionally `.claude/settings.json`.
 
 ## Key Principles
 
+- **Survey before asking** - the repo answers most tech stack questions itself
 - **One question at a time** - Don't overwhelm with multiple questions
 - **Multiple choice preferred** - Easier to answer than open-ended when possible
-- **DRY ruthlessly** - Remove any repetition of instructions
-- **Incremental validation** - Present `CLAUDE.md` in sections, validate each
+- **DRY ruthlessly** - Long rule sets live in their own file and get referenced, not pasted
+- **Assume nothing auto-loads** - outside Claude Code, a file is read only if the instructions say to read it
+- **Incremental validation** - Present each file in sections, validate each
 - **Be flexible** - Go back and clarify when something doesn't make sense
 
 ## Common Mistakes
 
-- Writing the whole CLAUDE.md at once instead of validating section by section with the user
+- Interviewing the user about a stack the lockfile and CI workflow already describe
+- Overwriting an existing CLAUDE.md or AGENTS.md instead of merging into it
+- Symlinking `AGENTS.md` to `CLAUDE.md` - it ships Claude Code's `@` imports and tool names to agents that understand neither
+- Leaving an `@` reference in `AGENTS.md`, where it is dead text
+- Writing `AGENT.md` instead of `AGENTS.md` - no agent reads the singular
+- Letting the two files drift after a command or boundary changes
+- Leaving `{{TEST_COMMAND}}` and friends unreplaced in the project's `TDD.rules.md`
+- Pasting the full TDD rules into either file instead of pointing at `TDD.rules.md`
+- Documenting commands without running them once to confirm they work
+- Writing a whole file at once instead of validating section by section with the user
 - Asking many questions in a single message and overwhelming the user
 - Paraphrasing the TDD rules or commit rules instead of copying them verbatim
-- Skipping the git commit after a section is confirmed

--- a/skills/setting-up-a-project/TDD.rules.md
+++ b/skills/setting-up-a-project/TDD.rules.md
@@ -1,4 +1,10 @@
-# Rules for Claude
+# Rules for the Coding Agent
+
+> **This file is a template.** Every `{{PLACEHOLDER}}` must be replaced with a real
+> value before it lands in a project. A shipped `{{TEST_COMMAND}}` is a bug.
+>
+> Referenced by `CLAUDE.md` and `AGENTS.md`. It applies to every agent working in
+> the repo, whichever entry file brought you here.
 
 ## ABSOLUTE RULES - NO EXCEPTIONS
 
@@ -26,17 +32,17 @@ If ANY of these occur, you MUST delete the code and start over:
 
 ### 3. Test Coverage Requirements
 
-- **Minimum 90%** coverage on ALL metrics:
-  - Lines: 90%+
-  - Functions: 90%+
-  - Branches: 85%+
-  - Statements: 90%+
+- **Minimum {{COVERAGE_THRESHOLD}}%** coverage on ALL metrics:
+  - Lines: {{COVERAGE_THRESHOLD}}%+
+  - Functions: {{COVERAGE_THRESHOLD}}%+
+  - Branches: {{BRANCH_COVERAGE_THRESHOLD}}%+
+  - Statements: {{COVERAGE_THRESHOLD}}%+
 - Coverage below threshold = Implementation incomplete
 - Untested code = Code that shouldn't exist
 
 ### 4. Implementation Order
 
-Follow the plan tasks listed in @IMPLEMENTATION_PLAN.md in EXACT order.
+If the project has an `IMPLEMENTATION_PLAN.md`, follow its tasks in EXACT order.
 
 ### 5. Before Writing ANY Code
 
@@ -49,10 +55,10 @@ If ANY answer is "no" → STOP. Write the test first.
 
 ### 6. Test File Structure
 
-For every production file, there MUST be a corresponding test file:
-- `src/example.ts` → `src/__tests__/example.test.ts`
-- `src/another-example.ts` → `src/__tests__/another-example.test.ts`
-- `src/causes_edge_cases.ts` → `src/__tests__/causes_edge_cases.test.ts`
+For every production file, there MUST be a corresponding test file. This project's
+convention:
+
+{{TEST_FILE_CONVENTION}}
 
 ### 7. Task Completion Requirements
 
@@ -60,8 +66,9 @@ For every production file, there MUST be a corresponding test file:
 - ✅ ALL tests pass (100% green)
 - ✅ Build succeeds with ZERO errors
 - ✅ NO linter errors or warnings
-- ✅ Coverage meets minimum thresholds (90%+)
+- ✅ Coverage meets minimum thresholds ({{COVERAGE_THRESHOLD}}%+)
 - ✅ Progress documented in PROGRESS.md
+- ✅ Work committed, following the Git Commit Rules in CLAUDE.md / AGENTS.md
 
 A task with failing tests, build errors, or linter warnings is INCOMPLETE. Period.
 
@@ -90,82 +97,42 @@ Format:
 - Notes: [any relevant notes]
 ```
 
-### 9. Git Commits - Commit Early, Commit Often
-
-**MANDATORY RULE**: COMMIT EARLY, COMMIT OFTEN
-
-- **Commit after EACH successful TDD cycle**:
-  - ✅ After RED-GREEN-REFACTOR cycle completes
-  - ✅ After each test file is created
-  - ✅ After each module implementation
-  - ✅ After fixing bugs or issues
-  - ✅ After updating documentation
-
-- **Frequency Requirements**:
-  - Minimum: After each completed subtask
-  - Maximum: No more than 30 minutes without a commit
-  - Never have more than one feature in a single commit
-
-- **Each commit MUST**:
-  - Have failing tests written first
-  - Pass all tests
-  - Build successfully
-  - Have no linter errors
-  - Meet coverage requirements (if code was added)
-  - Have progress documented
-  - Include clear commit message mentioning TDD
-
-- **Commit Message Format**:
-  ```
-  type(scope): brief description
-
-  - RED: What tests were written first
-  - GREEN: What minimal code was added
-  - Status: X tests passing, build successful
-  - Coverage: X% (if applicable)
-  ```
-
-- **Benefits of Frequent Commits**:
-  - Easy rollback if something breaks
-  - Clear history of TDD progression
-  - Smaller, reviewable changes
-  - Proof of TDD discipline
-
 ## Development Workflow
 
 For EACH feature/function:
 
 ```
 1. Write test file or add test case
-2. Run: <test command>
+2. Run: {{TEST_COMMAND}}
 3. See RED (test fails)
 4. Understand WHY it fails
 5. Write minimal production code
-6. Run: <test command>
+6. Run: {{TEST_COMMAND}}
 7. See GREEN (test passes)
 8. Refactor if needed
-9. Run: <test command> (stays green)
-10. Check coverage: <coverage command>
-11. Repeat for next feature
+9. Run: {{TEST_COMMAND}} (stays green)
+10. Check coverage: {{COVERAGE_COMMAND}}
+11. Commit (see the Git Commit Rules in CLAUDE.md / AGENTS.md)
+12. Repeat for next feature
 ```
 
 ## Commands You'll Use Constantly
 
 ```bash
 # Watch mode - keep this running ALWAYS
-<test command>
+{{TEST_WATCH_COMMAND}}
 
 # Run once
-<test command>
+{{TEST_COMMAND}}
 
 # Check coverage
-<coverage command>
+{{COVERAGE_COMMAND}}
 
 # Build - MUST succeed before task is complete
-<build command>
+{{BUILD_COMMAND}}
 
 # Check for Linter errors
-<linter command>
+{{LINT_COMMAND}}
 ```
 
 ## Red Flags - STOP Immediately
@@ -187,7 +154,7 @@ If you catch yourself:
 - Tests are not added after
 - Tests DRIVE the implementation
 - If it's not tested, it doesn't exist
-- Coverage below 90% = unfinished work
+- Coverage below {{COVERAGE_THRESHOLD}}% = unfinished work
 
 ## Accountability Check
 
@@ -196,10 +163,11 @@ Before marking ANY task complete, verify:
 2. ✓ Test failed first?
 3. ✓ Minimal code to pass?
 4. ✓ All tests green?
-5. ✓ Coverage maintained (90%+)?
-6. ✓ Build succeeds (`<build command>`)?
+5. ✓ Coverage maintained ({{COVERAGE_THRESHOLD}}%+)?
+6. ✓ Build succeeds (`{{BUILD_COMMAND}}`)?
 7. ✓ No linter errors?
 8. ✓ Progress documented in PROGRESS.md?
+9. ✓ Work committed?
 
 Missing ANY ✓ = Task is NOT complete. Fix it first.
 

--- a/skills/setting-up-a-project/git-commit-rules.md
+++ b/skills/setting-up-a-project/git-commit-rules.md
@@ -7,6 +7,18 @@
 - Commit before switching context or taking breaks
 - Never have more than 30 minutes of uncommitted work
 - Each commit should be atomic: one logical change per commit
+- Never put more than one feature in a single commit
+
+Every commit must pass all tests, build cleanly, and have no linter errors.
+
+### Commit Message Format
+
+```
+type(scope): brief description
+
+- What changed and why
+- Status: X tests passing, build successful
+```
 
 Why this matters:
 - Small commits are easier to review and revert

--- a/skills/working-on-an-issue/SKILL.md
+++ b/skills/working-on-an-issue/SKILL.md
@@ -11,7 +11,7 @@ description: Use when asked to work on, read, or implement a GitHub issue - hand
 
 A hands-off workflow for implementing GitHub issues. There are no approval gates before the pull request: the developer reviews finished work on the PR, so every judgment call you make must be recorded where they will see it.
 
-**Core principle:** Understand → Recon → Plan verification → Plan implementation → Implement → Verify → PR
+**Core principle:** Understand → Update project status → Recon → Plan verification → Plan implementation → Implement → Verify → PR
 
 **Create TodoWrite todos for the pre-flight checklist and each numbered step below.**
 
@@ -44,7 +44,43 @@ Do not invent requirements. Where the issue is ambiguous, choose the narrowest i
 
 **Assumptions resolve ambiguity in *how*, never reduce *what* the issue asks for.** Dropping a named request ("deferred the tour") is not an assumption — it's a scope cut, and scope cuts go through `issue-decomposition`, not the assumptions list. Manufacturing acceptance criteria the issue never stated to pass the sizing check is the same violation.
 
-### 2. Scoped Reconnaissance
+### 2. Update Linked Project Status
+
+Check whether the issue belongs to any GitHub Projects (v2). If it does, move it to an "in progress" style status in **every** project it belongs to before starting recon — this is what signals to anyone watching a board that work has actually begun.
+
+Query the issue's project items via GraphQL (`gh issue view --json` does not expose Projects v2 membership):
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $number) {
+        projectItems(first: 20) {
+          nodes {
+            id
+            project { id title number }
+          }
+        }
+      }
+    }
+  }' -F owner=<owner> -F repo=<repo> -F number=<number>
+```
+
+If `projectItems.nodes` is empty, the issue isn't tracked in any project — skip the rest of this step.
+
+For each project item returned, look up its status-like single-select field and options, then set it:
+
+```bash
+gh project field-list <project-number> --owner <owner> --format json   # locate the status field id + target option id
+gh project item-edit --id <item-id> --project-id <project-id> \
+  --field-id <status-field-id> --single-select-option-id <in-progress-option-id>
+```
+
+- Field and option names vary by project (`Status`/`In Progress`, `Doing`, `Started`, ...) — match case-insensitively on the option that most plausibly means "work has begun." If no such option exists, skip that project and note it rather than guessing.
+- Do this for every project item found, not just the first — an issue can belong to more than one project.
+- If the `gh` token lacks project scope or the update otherwise fails, don't block the workflow — record it as an assumption/caveat in the plan file and PR, and continue.
+
+### 3. Scoped Reconnaissance
 
 The issue bounds the exploration. Recon exists to *locate the change*, not to understand the codebase.
 
@@ -57,28 +93,28 @@ Stop exploring the moment you can answer all three:
 
 **Forbidden:** reading whole directories "for context", tracing beyond one hop, architecture surveys.
 
-### 3. Write the Verification Plan
+### 4. Write the Verification Plan
 
 Use the `writing-verification-plans` skill. This comes before the implementation plan because acceptance criteria define done and constrain the implementation.
 
-### 4. Write the Implementation Plan
+### 5. Write the Implementation Plan
 
 Use `superpowers:writing-plans` (if available) or write a brief plan covering: what changes, which files, order of implementation, risks, and the assumptions from step 1. Save to `docs/plans/issue-<number>-plan.md`, then proceed — do not wait for approval.
 
-### 5. Implement
+### 6. Implement
 
 - Follow TDD practices if `TDD.rules.md` is present (a project-level TDD rules file, if the repo defines one)
 - Commit after each logical change; reference the issue in commit messages (e.g. `fix: handle empty input (#123)`)
 - Unexpected complexity that invalidates the plan → update the plan file and note it for the PR description
 - Genuinely blocked (missing credentials, contradictory requirements) → comment on the issue and stop
 
-### 6. Execute Verification
+### 7. Execute Verification
 
 Run the verification plan and record results in the log format from `writing-verification-plans`.
 
 **If verification fails:** use `superpowers:systematic-debugging` to find the root cause — do not patch symptoms — then fix, re-run, and update the log. Never open the PR with failing verification (`superpowers:verification-before-completion` applies).
 
-### 7. Open the Pull Request
+### 8. Open the Pull Request
 
 Push the branch and create the PR: `gh pr create`. The PR body must include:
 

--- a/sync-agents-skills.sh
+++ b/sync-agents-skills.sh
@@ -28,3 +28,12 @@ for link in .agents/skills/*/; do
 done
 
 echo "Done! .agents/skills/ is in sync with skills/."
+
+# Mirror bundled rule sets into rules/ so they are fetchable by raw URL.
+# The copy inside the skill is canonical: single-skill plugin installs use
+# "source": "./skills/<name>", so the skill must stay self-contained. A symlink
+# would dangle there, and raw.githubusercontent.com serves a symlink as its
+# target path rather than the file contents - so this is a real copy.
+mkdir -p rules
+cp skills/setting-up-a-project/TDD.rules.md rules/TDD.rules.md
+echo "Mirrored rules/TDD.rules.md from skills/setting-up-a-project/."


### PR DESCRIPTION
Reworks `setting-up-a-project` so it surveys the repo before interviewing, records a Commands section it actually runs before committing, and writes two instruction files instead of one — `CLAUDE.md` with Claude Code's `@` imports and tool names, plus a separately tuned `AGENTS.md` for Codex CLI, OpenCode, and Cursor whose required-reading list works where nothing auto-loads. `TDD.rules.md` now installs at the project root with its `{{PLACEHOLDER}}` values filled from the interview rather than being pasted into every session's context, its duplicated commit rules move to `git-commit-rules.md`, PR conventions and coverage thresholds become interview questions instead of hardcoded dictates, and the stale `claude-code-skills` fallback URL is fixed. `rules/TDD.rules.md` becomes a mirror refreshed by `sync-agents-skills.sh`, since single-skill installs use `"source": "./skills/<name>"` and must stay self-contained.

Separately, `working-on-an-issue` gains a step that moves an issue to an "in progress" status in every GitHub Project (v2) it belongs to before recon begins, via GraphQL — `gh issue view --json` does not expose Projects v2 membership — treating missing project scope as a recorded caveat rather than a blocker.

Docs, the site pages, and the plugin/bundle versions are updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)